### PR TITLE
Fix: Auto-approve workflow token configuration

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -15,4 +15,4 @@ jobs:
       - name: Auto-approve PR
         uses: hmarr/auto-approve-action@v4
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.AUTO_APPROVE_PAT }}


### PR DESCRIPTION
Quick fix to use AUTO_APPROVE_PAT instead of GITHUB_TOKEN for auto-approval workflow.