### PR TITLE
Migrate to modern bare-repo worktree structure

### DIFF
--- a/.claude/.claude
+++ b/.claude/.claude
@@ -1,1 +1,0 @@
-../../.shared/.claude

--- a/.claude/agents
+++ b/.claude/agents
@@ -1,1 +1,0 @@
-../../../.shared/.claude/agents

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,1 +1,0 @@
-../../../.shared/.claude/settings.local.json

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,1 +1,0 @@
-../../../.shared/.claude/skills

--- a/.gitignore
+++ b/.gitignore
@@ -16,27 +16,7 @@ lerna-debug.log*
 
 # Environment
 .env
-.env.local
 *.local
-
-# Worktrees directory
-/wt/
-
-# Shared directory - personal files not committed
-/.shared/
-
-# Confidential context (if symlinked to root)
-CLAUDE.md
-CLAUDE_CONTEXT.md
-
-# Planning and scratch (if symlinked to root)
-.planning
-.scratch
-
-# Claude Code personal settings (symlinked in worktrees)
-.claude/agents
-.claude/settings.local.json
-.claude/skills
 
 # Testing
 coverage/
@@ -63,4 +43,3 @@ tests/e2e/**/__diff_output__/
 # OS
 .DS_Store
 Thumbs.db
-.scratch/


### PR DESCRIPTION
## Summary

- Stop tracking `.claude/` symlinks (settings.local.json, skills, agents) - these are per-worktree files that point to `.shared/.claude/`
- Move local setup entries from `.gitignore` to `.bare/info/exclude` - keeps repo-specific local config out of the public `.gitignore`

## Context

This is part of migrating BroteinBuddy to a modern worktree structure where:
- The repo uses a bare clone (`.bare/`) with all branches as worktrees
- Shared resources live in `.shared/` and are symlinked into each worktree
- Local exclusions are in `.bare/info/exclude` rather than tracked `.gitignore`

## Test plan

- [x] Verified symlinks resolve correctly in worktrees
- [x] Verified `.scratch/` and `.planning/` files accessible
- [x] Verified `git status` is clean after changes
- [x] Tested `setup-worktree.py` creates worktrees correctly

Generated with [Claude Code](https://claude.com/claude-code)
Steered and verified by @nikblanchet