### PR TITLE
Add local event timeline (PR 1 of 3 toward multi-device data backend)

### DIFF
--- a/docs/adr/011-event-timeline.md
+++ b/docs/adr/011-event-timeline.md
@@ -1,0 +1,128 @@
+# ADR-011: Local Event Timeline
+
+**Status:** Accepted
+
+**Date:** 2026-05-14
+
+**Deciders:** Nik Blanchet
+
+---
+
+## Context
+
+### Background
+
+BroteinBuddy currently persists a single `AppState` snapshot to LocalStorage. The schema captures _what_ is true now (boxes, flavors, favorite, settings) but not _what happened_: when boxes arrived, when they were opened, when shakes were taken, or which suggestions the user rejected. The backup/restore feature (ADR-010) serializes the snapshot but has no historical content.
+
+We plan to evolve the data layer in three staged PRs:
+
+1. **(this PR) Local event timeline** — capture events client-side in LocalStorage.
+2. **Server + auth** — Supabase project with magic-link sign-in; push state and events on login, pull on app start.
+3. **Multi-device sync** — realtime subscribe, offline event queue, conflict resolution, sync UI.
+
+This ADR covers PR 1 only.
+
+### Problem Statement
+
+The user wants:
+
+- Visibility into when boxes were received and opened.
+- A record of every shake taken — including the _method_ of selection (random pool / manual / favorite).
+- A record of "no-transaction" moments — pressing _Different Choice_ (rejecting a suggestion) and _Cancel_.
+- A foundation for later reporting ("when do I take shakes?", "which flavors do I skip?") without specifying any UI yet.
+
+The constraints are:
+
+- Stay 100% client-side for this PR. No server, no auth, no network calls.
+- Keep the existing backup/restore round-trip working (ADR-010).
+- Preserve the migration framework (ADR-003) so users with v2 data upgrade transparently.
+- Don't bloat LocalStorage unnecessarily; events grow over time.
+
+## Decision
+
+We will **embed an append-only `events: AppEvent[]` array inside `AppState`** and bump the schema to v3. Six event types capture exactly the user-visible actions enumerated above:
+
+| Type                  | When emitted                                                   |
+| --------------------- | -------------------------------------------------------------- |
+| `box_received`        | A box is added to inventory (`addBox`)                         |
+| `box_opened`          | A box transitions `isOpen: false → true` (`updateBoxIsOpen`)   |
+| `box_removed`         | A box is deleted (`removeBox`)                                 |
+| `shake_taken`         | Selection confirmed; quantity decremented (`recordShakeTaken`) |
+| `shake_rejected`      | User clicked _Different Choice_ (`recordShakeRejected`)        |
+| `selection_cancelled` | User clicked _Cancel_ (`recordSelectionCancelled`)             |
+
+Every event has `id` (`ev_<uuid>`), `timestamp` (ISO 8601), and `type`. `shake_*` and `selection_*` events also carry `method: 'random' | 'manual' | 'favorite'` and `pool: 'caffeinated' | 'caffeine-free' | null`.
+
+### Implementation Details
+
+- **Schema**: `events: AppEvent[]` lives on `AppState` directly. The `isAppState` type guard validates the array; each event passes a per-variant `isAppEvent` guard.
+- **Migration**: v2 → v3 adds `events: []`. v1 → v3 chains through v1 → v2 → v3 transparently. The migration is idempotent. **No synthetic backfill** for existing boxes — we don't know their true received dates and would rather have an honestly empty timeline than fabricated timestamps.
+- **Event factory**: `lib/events.ts` exports a pure `createEvent(type, payload)` factory using `crypto.randomUUID()` and `new Date().toISOString()`. No store coupling.
+- **Store integration**: `addBox`, `removeBox`, and `updateBoxIsOpen` emit their events inside the same `appState.update` call as the mutation — one atomic write. Three new actions (`recordShakeTaken`, `recordShakeRejected`, `recordSelectionCancelled`) live alongside the existing box/flavor mutators.
+- **Selection flow**: `RandomConfirm.svelte` snapshots `selectedMethod` and `selectedPool` on mount and uses them when emitting events. `Home.svelte` sets `selectedMethod` (new writable in `lib/navigation-state.ts`) for each entry path: `'random' | 'manual' | 'favorite'`.
+- **Backup**: No change to `lib/backup.ts`. Events are part of `AppState` so they flow through `exportStateAsJson` / `parseBackupJson` automatically.
+
+## Consequences
+
+### Positive
+
+- The user immediately has an audit trail of selections, rejections, and box lifecycle events, visible in any backup JSON export.
+- The event schema is stable before PR 2 introduces server sync, so the server can be designed around it rather than retrofitted.
+- Adding new event types in the future is purely additive — no schema bump required as long as `events` stays an array.
+- Backup files carry the timeline, so users restoring from a backup keep their history.
+
+### Negative
+
+- LocalStorage write size grows with the event log. At ~10 events/day × 200 bytes/event, ~700 KB/year. Well under the 5–10 MB LocalStorage limit but worth monitoring.
+- The auto-save subscription writes the full `AppState` on every event. With many events per session that's measurably more I/O than today, though still synchronous and small.
+- The event log is unbounded. We don't truncate or compact. Eventually we may need a rolling window or compaction (likely in PR 3 alongside the offline queue).
+
+### Neutral
+
+- Existing inventory edits via the Inventory page (manual `updateBoxQuantity` and `updateBoxLocation`) do **not** emit events in this PR. We can add them later without a schema change. The plan focuses on the selection timeline you asked for.
+- Box close (`isOpen: true → false`) is not recorded. The product question "when did I close this box?" wasn't asked for. Symmetric `box_closed` is trivially addable later.
+
+## Alternatives Considered
+
+### Alternative 1: Separate LocalStorage key for events
+
+Store events under `BROTEINBUDDY_EVENT_LOG` rather than inside `AppState`.
+
+- **Pros**: Smaller writes when only an event is appended (don't re-serialize all boxes/flavors). Better when the log gets large.
+- **Cons**: Two atoms to keep consistent; backup/restore would need to merge two payloads; harder to reason about. With current scale, embedded wins.
+
+Rejected for PR 1. We can extract events to a separate key in a future migration if the embedded log proves too costly.
+
+### Alternative 2: Synthetic backfill on migration
+
+When migrating v2 → v3, emit `box_received` events for every existing box with `timestamp` = migration date.
+
+- **Pros**: Timeline isn't empty on day one.
+- **Cons**: Timestamps are wrong (all bunched on migration day). Misleads any future analytics.
+
+Rejected. An honestly empty timeline is better than a fabricated one. The user can interpret "no event = pre-upgrade box" cleanly.
+
+### Alternative 3: Event-sourced state (events as the only source of truth)
+
+Store only events; derive boxes/flavors by replaying.
+
+- **Pros**: Elegant; classic CQRS/ES pattern.
+- **Cons**: Massive refactor of every read path. Read performance hits scale O(events) on every page load. Overkill for a hobby PWA with one user.
+
+Rejected. Snapshot + append-only log is the pragmatic middle ground.
+
+### Alternative 4: Defer to PR 2
+
+Capture events only once the server exists.
+
+- **Pros**: One fewer schema migration.
+- **Cons**: The user gets no timeline until the multi-week server work lands. Also, PR 2 has nothing concrete to sync.
+
+Rejected. Doing PR 1 first gives the user value immediately and gives PR 2 a stable schema to design against.
+
+## References
+
+- ADR-002: Data Model Design
+- ADR-003: LocalStorage Strategy (migration framework)
+- ADR-010: Backup/Restore Design
+- Plan file: `/Users/nik/.claude/plans/i-would-like-to-staged-reef.md`

--- a/docs/teaching/1.6-event-timeline-design.md
+++ b/docs/teaching/1.6-event-timeline-design.md
@@ -1,0 +1,954 @@
+# The Local Event Timeline: Snapshots, Events, and Designing for Sync
+
+**Deliverable:** 1.6 — Local Event Timeline (PR #94, branch `feature/local-event-timeline`)
+**Author:** Claude Code
+**Date:** 2026-05-14
+**Skill Level:** Intermediate / Architectural
+
+---
+
+## Table of Contents
+
+1. [What Changed and Why It Matters](#what-changed-and-why-it-matters)
+2. [Snapshot vs Event Log: A Modeling Shift](#snapshot-vs-event-log-a-modeling-shift)
+3. [The Discriminated Union and Why It's Worth the Verbosity](#the-discriminated-union-and-why-its-worth-the-verbosity)
+4. [The `createEvent` Factory: One Generic, Five Variants](#the-createevent-factory-one-generic-five-variants)
+5. [Atomic Emission: Same `update`, Same Write](#atomic-emission-same-update-same-write)
+6. [Migration as a Chain, Not a Switch](#migration-as-a-chain-not-a-switch)
+7. [No Synthetic Backfill (and Why That's a Discipline, Not a Shortcut)](#no-synthetic-backfill-and-why-thats-a-discipline-not-a-shortcut)
+8. [Why the Timeline Lives Inside `AppState`](#why-the-timeline-lives-inside-appstate)
+9. [Designed for Sync: PR 2 and PR 3 Live Inside This One](#designed-for-sync-pr-2-and-pr-3-live-inside-this-one)
+10. [What We Deliberately Did NOT Do](#what-we-deliberately-did-not-do)
+11. [Further Reading](#further-reading)
+
+---
+
+## What Changed and Why It Matters
+
+Before this PR, BroteinBuddy was a pure **snapshot store**. `AppState` answered
+exactly one question: _what is true right now?_ How many boxes do you have,
+which flavors are configured, which is your favorite. The snapshot was
+serialized to LocalStorage, validated on load, migrated when schema versions
+changed, and round-tripped through the backup/restore JSON file (see
+ADR-010, ADR-003).
+
+That snapshot model is fine — until the moment you want to ask a different
+shape of question. _When_ did you receive that box? _How_ did you pick today's
+shake — random pool, manual, or favorite quick-pick? Which flavors did you
+keep rejecting via "Different Choice" before settling? None of those are in
+the snapshot, because the snapshot is intentionally _ahistorical_.
+
+This PR adds a second axis to the data model: an **append-only timeline of
+events**, declared on `AppState` as `events: AppEvent[]` (see
+`src/types/models.ts:222`). Every user-visible action — box received, box
+opened, box removed, shake taken, shake rejected, selection cancelled — emits
+a typed, timestamped event. The snapshot still answers "what is true now,"
+and the event log now answers "how did we get here." Both live inside the
+same `AppState` value, both are persisted in the same LocalStorage write,
+both round-trip through backup/restore for free.
+
+That is the shape of the change. The rest of this document is about _why_
+each piece looks the way it does, and what it sets up for the next two PRs
+in the data-layer evolution: a Supabase + magic-link backend (PR 2) and
+realtime multi-device sync with an offline queue (PR 3).
+
+## Snapshot vs Event Log: A Modeling Shift
+
+When you've only ever modeled state as a snapshot, adding events feels like
+"just another array." It isn't. The two have different shapes, different
+strengths, and they answer different questions. It's worth sitting with that
+distinction before getting into code.
+
+### What a snapshot is good at
+
+A snapshot is the **current truth**. Reads are cheap (no replay), writes are
+total (you overwrite the previous value), and the schema lines up neatly with
+the UI: you have a `boxes: Box[]`, you render a list of boxes.
+
+What a snapshot _cannot_ tell you:
+
+- When did this box arrive?
+- How many shakes did I take last week?
+- Which flavors did I dismiss via "Different Choice"?
+- What was the state on Tuesday at 3pm?
+
+The snapshot is a single point on the timeline. Everything before "now" is
+gone the moment a write happens.
+
+### What an event log is good at
+
+An event log is the **history**. Each event is immutable. The log grows
+forever (subject to compaction or windowing strategies we'll get to in PR 3).
+Reads of "what happened" are cheap. _Derived state_ from the log — "how many
+shakes this week" — requires aggregation, but you can compute it any way
+you like, and you can compute new aggregations from old events you never
+anticipated.
+
+What an event log _alone_ cannot give you cheaply:
+
+- The current quantity of box `box_123` (you'd have to replay every
+  `shake_taken` and every `box_received` for that box, from the beginning of
+  time, on every read).
+
+That last bullet is the heart of why we did not go full **event sourcing**.
+
+### The middle ground: snapshot + append-only event log
+
+Martin Fowler's [Event Sourcing][fowler-es] pattern says: "store every state
+change as a sequence of events, and reconstruct state by replaying them."
+It's elegant, well-trodden, and used in plenty of serious systems (banking,
+audit trails, CQRS-shaped backends).
+
+For BroteinBuddy, it would be malpractice. The reasons are concrete:
+
+1. **Every read path becomes a fold.** Today, "show me the box list" is one
+   array dereference. Under pure ES, it becomes "replay every event since
+   the beginning of time to derive the current box list." For a hobby PWA
+   running in a browser, that's an O(N events) cost on every page load
+   forever. Snapshots fix that — but then you're back to the hybrid we
+   actually built.
+2. **The UI does not need the audit trail to render.** The Home screen,
+   Random flow, and Inventory page all want _current_ truth. They never
+   replay history. Forcing every read to be a derivation would be paying
+   for a feature nobody is using.
+3. **One user, one device, no audit requirement.** ES shines when you need
+   correctness guarantees in the face of distributed writers, when
+   regulators demand a trail, or when you might want to retroactively
+   change how derived state is computed. None of those apply here.
+
+So we picked the pragmatic middle: **the snapshot is still the source of
+truth for reads, and the event log is an additive, ordered record of writes.**
+ADR-011's "Alternatives Considered" section rejects pure ES for exactly
+this reason. The snapshot stays authoritative. The events are how we know
+_how_ the snapshot got here.
+
+Think of it like a database with both a primary key-value store and a
+write-ahead log. The kv-store is fast for reads, the WAL is the source of
+truth for recovery and replication. We're using the same shape, just at
+hobby-app scale, and we're calling them `boxes`/`flavors` and `events`.
+
+## The Discriminated Union and Why It's Worth the Verbosity
+
+The `AppEvent` type is a **discriminated union** of six per-variant
+interfaces (`src/types/events.ts:106-112`):
+
+```ts
+export type AppEvent =
+  | BoxReceivedEvent
+  | BoxOpenedEvent
+  | BoxRemovedEvent
+  | ShakeTakenEvent
+  | ShakeRejectedEvent
+  | SelectionCancelledEvent;
+```
+
+Each variant carries the shared base (`id`, `timestamp`) and its own
+type-literal discriminator (`type: 'box_received'`, etc.), plus whatever
+variant-specific payload that event needs (`boxId`, `flavorId`, `method`,
+`pool`, …). The corresponding type guard, `isAppEvent`, switches on the
+discriminator and validates the payload for each branch
+(`src/types/events.ts:146-199`).
+
+This is verbose. There are six interfaces. There is a switch statement in
+the type guard. There is a `EventMethod` enum and an `EventPool` enum and
+their own narrow guards (`isEventMethod`, `isEventPool`,
+`src/types/events.ts:119-125`). It would have been shorter to do almost
+anything else. Let's walk through what we _didn't_ do and why.
+
+### Alternative 1: A single `{ type, payload }` shape
+
+```ts
+// Tempting, but loses everything we care about
+interface AppEvent {
+  id: string;
+  timestamp: string;
+  type: string;
+  payload: Record<string, unknown>;
+}
+```
+
+This is the "stringly-typed" trap. Once `payload` is a bag of unknowns,
+TypeScript stops helping. Every consumer needs a runtime check before
+touching any field — and worse, they have to _know_ which fields exist for
+which `type`, by reading docs or grepping the codebase, instead of letting
+the compiler enforce it. A typo in a key (`flavour_id` vs `flavorId`) is now
+a silent runtime bug.
+
+The discriminated union gives us the opposite property: if you write
+
+```ts
+function handle(ev: AppEvent) {
+  if (ev.type === 'shake_taken') {
+    ev.pool; // TS narrows this to EventPool. ev.location would be a compile error.
+  }
+}
+```
+
+…TypeScript narrows the type inside the branch. You cannot accidentally
+access `ev.location` here, because `ShakeTakenEvent` doesn't have one. That
+is the whole point of the pattern.
+
+### Alternative 2: A class hierarchy
+
+`AppEvent` could have been an abstract base class with concrete subclasses
+(`BoxReceivedEvent extends AppEvent`, etc.). This works in many OO
+languages. In TypeScript-on-JSON-on-LocalStorage, it actively hurts:
+
+1. **`JSON.parse` cannot reconstruct classes.** What you get back from
+   storage is a plain object. You'd need a hand-rolled factory ("if
+   `type === 'box_received'`, `new BoxReceivedEvent(obj)`") which is the
+   discriminated-union switch with extra steps and a prototype chain you
+   don't need.
+2. **`instanceof` is unreliable across realms.** Backups round-trip through
+   a JSON file; the restored events are plain objects. Any code that asks
+   `ev instanceof BoxReceivedEvent` will return false even though the
+   shape is correct.
+3. **No discriminator narrowing.** With classes you tend to dispatch on
+   `instanceof` or on virtual methods. The TS literal-narrowing magic that
+   makes `switch (ev.type)` so pleasant only works on tagged unions.
+
+Tagged unions are the runtime-friendly cousin of classes for this use case.
+The "Tagged errors over class hierarchies" point in `3.6-json-file-backup-pattern.md`
+applies for the same reasons.
+
+### Alternative 3: Runtime schema library (Zod)
+
+We could declare the events with Zod and get parsing + validation in one
+step:
+
+```ts
+const ShakeTakenEvent = z.object({
+  id: z.string(),
+  timestamp: z.string(),
+  type: z.literal('shake_taken'),
+  // ...
+});
+```
+
+Zod's errors are objectively nicer — it can tell you "shake_taken event at
+events[42] is missing field `pool`." The project considered Zod in ADR-003
+and rejected it for the snapshot validation path; the calculus didn't change
+for events. The reasons stayed:
+
+- **Bundle weight.** Zod is ~14 KB minified. For a PWA optimizing for
+  install size on iOS, that's noticeable for a feature whose error
+  messages are read by exactly one developer.
+- **Consistency with the existing codebase.** `isBox`, `isFlavor`,
+  `isLocation`, `isAppState` are all hand-written type guards. Mixing
+  guards and Zod schemas would mean two parallel validation styles.
+- **Diminishing returns on validation depth.** Hand-rolled guards already
+  do per-field type checks and integer-non-negative checks. The error
+  messages are coarser, but the only consumer is `console.warn` followed
+  by "use default state."
+
+This is exactly the tradeoff ADR-002 (type-driven design) called out: prefer
+narrow, hand-written type guards for the small amount of untrusted data
+this app touches. The cost of switching now would be high, and the benefit
+is largely cosmetic for a single-developer project.
+
+If error messages from corrupted events ever become a usability complaint,
+Zod gets a fresh look — but probably _project-wide_, not just here.
+
+### The cost we accepted
+
+Adding a new event type is more friction than it would be with a generic
+shape:
+
+1. Define the interface in `src/types/events.ts`.
+2. Add it to the `AppEvent` union (`src/types/events.ts:106-112`).
+3. Add a `case` branch in `isAppEvent` (`src/types/events.ts:152-198`).
+4. Emit it from the relevant store action.
+
+That four-step ceremony is explicit, listed in a comment at the top of the
+union (`src/types/events.ts:97-104`). It's not invisible work, but it's
+linear and the compiler tells you what you missed. The payoff every time
+you _consume_ an event — narrowing, autocomplete, exhaustiveness checking —
+makes the trade obvious to me. Your mileage may vary if you're shipping
+many event types per week. For BroteinBuddy's pace, it's clearly the right
+call.
+
+## The `createEvent` Factory: One Generic, Five Variants
+
+`lib/events.ts` exists for one purpose: to build a fully-formed
+`AppEvent` from a payload, without coupling that construction to the Svelte
+store or LocalStorage. Here is the whole file:
+
+```ts
+type EventOf<T extends AppEventType> = Extract<AppEvent, { type: T }>;
+type EventPayload<T extends AppEventType> = Omit<EventOf<T>, 'id' | 'timestamp' | 'type'>;
+
+export function createEvent<T extends AppEventType>(type: T, payload: EventPayload<T>): EventOf<T> {
+  return {
+    id: `ev_${crypto.randomUUID()}`,
+    timestamp: new Date().toISOString(),
+    type,
+    ...payload,
+  } as EventOf<T>;
+}
+```
+
+(`src/lib/events.ts:14-46`)
+
+This is a small but dense piece of TypeScript. The trick is in those two
+type aliases at the top:
+
+- `EventOf<T>` uses `Extract` to pick the union member whose `type` literal
+  matches `T`. So `EventOf<'shake_taken'>` resolves to `ShakeTakenEvent`,
+  not to the whole union.
+- `EventPayload<T>` is `EventOf<T>` minus the three fields the factory
+  fills in (`id`, `timestamp`, `type`). So the second parameter to
+  `createEvent('shake_taken', _)` is exactly "the variant-specific
+  payload, nothing more, nothing less."
+
+This means a typo at the call site is a compile error:
+
+```ts
+createEvent('shake_taken', {
+  boxId: 'box_123',
+  flavorId: 'flavor_chocolate',
+  method: 'random',
+  pool: 'caffeinated',
+  // adding `location: ...` here would be a TS error
+}); // ✓ type-narrowed to ShakeTakenEvent
+
+createEvent('shake_taken', {
+  boxId: 'box_123',
+  // missing flavorId, method, pool → compile error
+}); // ✗
+```
+
+And the return type is the narrow variant, not the union. If the caller
+does `const ev = createEvent('shake_taken', ...)`, `ev` is typed as
+`ShakeTakenEvent`, not `AppEvent`. The narrowing flows downstream.
+
+A few small choices inside the factory that are easy to miss:
+
+- **`crypto.randomUUID()` for the ID.** Matches the existing
+  `lib/utils/id.ts` pattern. It's a modern browser API, available in every
+  PWA target. The `ev_` prefix is namespacing — the same way `box_` and
+  `flavor_` IDs are prefixed elsewhere — so you can identify the entity
+  type at a glance when staring at JSON.
+- **`new Date().toISOString()` for the timestamp.** ISO 8601 strings sort
+  lexicographically the same way they sort chronologically, which is one
+  of those small properties that you only appreciate when it saves you.
+  PR 3 will care about timestamp ordering across devices; storing as ISO
+  strings means the trivial `events.sort((a, b) => a.timestamp.localeCompare(b.timestamp))`
+  is correct. (Strictly speaking, monotonicity per-device requires more
+  care; we'll come back to that.)
+- **The `as EventOf<T>` cast at the end.** TypeScript's structural typing
+  can't quite prove that `{ id, timestamp, type, ...payload }` matches the
+  narrow variant — `T` and `payload` are related by `EventPayload<T>`, but
+  the compiler doesn't fold that all the way through the spread. The cast
+  is a controlled escape hatch. The runtime shape is correct; we're just
+  asserting it for the type system.
+- **No store import.** This file imports types and nothing else. That's
+  deliberate. The factory is pure (modulo `crypto.randomUUID` and
+  `Date.now()` via `toISOString`), which makes it trivially testable
+  (`tests/unit/events.test.ts` mocks both sources and asserts the output
+  shape). The same separation rule that the backup/restore feature follows
+  for `backup.ts`: pure logic in one file, DOM/store ceremony elsewhere.
+
+## Atomic Emission: Same `update`, Same Write
+
+Here's the part that's easy to get subtly wrong. Look at how `addBox` emits
+its event (`src/lib/stores.ts:139-160`):
+
+```ts
+export function addBox(box: Box): void {
+  appState.update((state) => {
+    if (state.boxes.some((b) => b.id === box.id)) {
+      throw new Error(`Box with ID "${box.id}" already exists`);
+    }
+
+    const event = createEvent('box_received', {
+      boxId: box.id,
+      flavorId: box.flavorId,
+      quantity: box.quantity,
+      location: box.location,
+      isOpen: box.isOpen,
+    });
+
+    return {
+      ...state,
+      boxes: [...state.boxes, box],
+      events: [...state.events, event],
+    };
+  });
+}
+```
+
+Notice that **the event is created and appended inside the same
+`appState.update` callback as the box mutation**, and they are returned as
+part of the same new state object. The store sees one transition: from
+"state without this box and without this event" to "state with both."
+
+The same shape shows up in `removeBox` (`src/lib/stores.ts:178-198`),
+`updateBoxIsOpen` (which only emits on the false→true transition,
+`src/lib/stores.ts:310-345`), and `recordShakeTaken`
+(`src/lib/stores.ts:477-513`). The non-mutating actions
+(`recordShakeRejected`, `recordSelectionCancelled`) use a tiny internal
+helper `appendEvent` that also goes through a single `update`
+(`src/lib/stores.ts:560-565`).
+
+### Why this matters
+
+Imagine the naive alternative: mutate, then emit.
+
+```ts
+// DO NOT DO THIS
+export function addBoxBad(box: Box): void {
+  appState.update((state) => ({
+    ...state,
+    boxes: [...state.boxes, box],
+  }));
+  // …subscribers fire here, LocalStorage is written with the new box
+  //   but no event yet
+  appState.update((state) => ({
+    ...state,
+    events: [
+      ...state.events,
+      createEvent('box_received', {
+        /* ... */
+      }),
+    ],
+  }));
+  // …subscribers fire AGAIN, LocalStorage is written with the event
+}
+```
+
+Three things go wrong:
+
+1. **Subscribers fire twice.** Every component subscribed to `appState`
+   re-renders twice for one logical action. For a tiny app on a fast
+   device, nobody notices. For a slower device, or for derived stores that
+   do expensive computation, this is a real cost.
+2. **There is a window where the snapshot and the log disagree.** If the
+   page crashes _between_ the two updates (yes, JS pages can crash —
+   memory limits on iOS Safari, browser termination, anything), you've
+   persisted "box exists, event doesn't." A future analytics pass over the
+   timeline will under-count box receipts. The snapshot is "right," the
+   log is "wrong," and they will never reconcile because you don't know
+   that the second `update` was lost.
+3. **You can't distinguish "the user added a box" from "two unrelated
+   operations that happen to be temporally adjacent."** Future you, or a
+   future debugging session, sees two writes in the LocalStorage history
+   and can't tell whether they came from one intent or two.
+
+The atomic version has none of these problems. One `update` callback
+returns one new state value. Subscribers fire once. LocalStorage gets one
+write. The snapshot and the log advance together or not at all.
+
+> **General principle (worth tattooing somewhere):** When a single user
+> action has multiple effects on state, perform all those effects inside a
+> single state-transition function. Don't fan them out to multiple
+> top-level mutations. This is the same principle as a database
+> transaction: either everything commits or nothing does. The store's
+> `update` callback is your transaction boundary.
+
+### `recordShakeTaken` is the cleanest example
+
+`recordShakeTaken` was introduced specifically for the selection-confirm
+flow (`src/lib/stores.ts:477-513`). It replaces what _used_ to be a call
+to `updateBoxQuantity(boxId, box.quantity - 1)` from `RandomConfirm.svelte`.
+
+The old code path mutated quantity and that's it. The new code path mutates
+quantity _and_ records why the shake was taken (random pool, manual,
+favorite), in one update. That is a meaningful API shift: callers no longer
+say "decrement the quantity on this box," they say "the user took a shake;
+here's everything you need to know about it." The store action becomes the
+boundary where intent meets state.
+
+The selection-confirm screen
+(`src/routes/RandomConfirm.svelte:115-127`) consequently looks like:
+
+```ts
+recordShakeTaken({
+  boxId: priorityBox.id,
+  flavorId: selectedFlavorId,
+  method: selectionMethod,
+  pool: selectionPool,
+});
+```
+
+…with no follow-up call to anything else. The single function says
+everything that needs to happen.
+
+## Migration as a Chain, Not a Switch
+
+The schema went from v2 to v3 in this PR — `events: AppEvent[]` is the new
+field, defaulting to `[]`. The migration code now looks like this
+(`src/lib/storage.ts:177-210`):
+
+```ts
+export function migrateState(data: unknown): unknown {
+  if (typeof data !== 'object' || data === null || !('version' in data)) {
+    return data;
+  }
+
+  let current = data as Record<string, unknown> & { version: number };
+
+  if (current.version === 1 && Array.isArray(current.flavors)) {
+    // v1 → v2: excludeFromRandom: boolean → randomPool: RandomPool | null
+    // ...
+    current = {
+      ...current,
+      version: 2,
+      flavors: migratedFlavors,
+    };
+  }
+
+  if (current.version === 2) {
+    current = {
+      ...current,
+      version: 3,
+      events: [],
+    };
+  }
+
+  return current;
+}
+```
+
+Two `if` blocks. Sequential, mutating a local `current` variable. Notice
+what is _not_ here:
+
+- No `switch (data.version)`.
+- No "if v1, do the v1-to-v3 transform directly."
+- No "if v2 _or_ v3, just return."
+
+This shape is deliberate. It's the "chained migrations" pattern called out
+in ADR-003 and in `3.6-json-file-backup-pattern.md` ("Add a future schema
+version"). Let's walk through why it scales and what would have been wrong
+about the alternatives.
+
+### Why not a switch on the source version?
+
+```ts
+// DON'T do this
+switch (data.version) {
+  case 1:
+    return migrateV1ToV3(data); // hand-written end-to-end
+  case 2:
+    return migrateV2ToV3(data); // separate function
+  case 3:
+    return data;
+}
+```
+
+This works for two source versions. It scales linearly in code, but **the
+cost is duplication of intermediate transformations**. The v1→v3 function
+has to know v1's flavor format _and_ v2's `events` defaulting. The v2→v3
+function only knows the latter. The day v4 ships, you now have three
+functions to maintain (v1→v4, v2→v4, v3→v4), each of which duplicates
+every prior step. Add v5, v6, and you have an O(N²) maintenance burden
+where N is the number of schema versions.
+
+The chained approach is O(N). v1 data flows through v1→v2 and then v2→v3.
+v2 data skips the first block and only hits the second. Each migration
+step needs to know **only** the prior version's shape and the next
+version's shape. Future migrations stack onto the bottom; existing ones
+don't change.
+
+### Idempotency
+
+A v3 payload entering `migrateState` falls through both `if` blocks
+unchanged. The function returns the same value (modulo the cast). This is
+**idempotent**: `migrateState(migrateState(x)) === migrateState(x)` for
+any `x`. That's not just an aesthetic property — it means the function is
+safe to call defensively from anywhere, including the backup-restore path
+(`lib/backup.ts` runs `migrateState` on file contents before validating),
+without worrying that data already at the current version will be
+corrupted.
+
+### How to add v4
+
+When the schema needs a fourth version — say, you add a `createdAt`
+timestamp to `Box` — the pattern is:
+
+```ts
+if (current.version === 3) {
+  const migratedBoxes = (current.boxes as Box[]).map((box) => ({
+    ...box,
+    createdAt: 'unknown', // or: whatever default makes sense
+  }));
+  current = {
+    ...current,
+    version: 4,
+    boxes: migratedBoxes,
+  };
+}
+```
+
+Added at the bottom, between the existing v2→v3 block and the `return`.
+No existing code changes. Tests for v1→v3 and v2→v3 still pass; you add a
+new test for v3→v4 and a multi-hop test that runs v1 all the way to v4 to
+make sure the chain holds.
+
+> **General principle:** When you have a pipeline of transformations where
+> each step depends only on the previous one, chain them. Don't write
+> separate end-to-end functions per starting point. The chain is shorter
+> to write, easier to test, and trivial to extend.
+
+## No Synthetic Backfill (and Why That's a Discipline, Not a Shortcut)
+
+When v2 → v3 ran for the first time on a real device, it found existing
+boxes — boxes that were _received_ at some point in the past, but for which
+no `box_received` event exists, because the event timeline did not exist
+yet.
+
+There were two ways to handle that:
+
+### Option A: Fabricate `box_received` events for existing boxes
+
+```ts
+// DON'T do this
+if (current.version === 2) {
+  const now = new Date().toISOString();
+  const backfilledEvents = (current.boxes as Box[]).map((box) =>
+    createEvent('box_received', {
+      boxId: box.id,
+      flavorId: box.flavorId,
+      quantity: box.quantity,
+      location: box.location,
+      isOpen: box.isOpen,
+    })
+  );
+  current = {
+    ...current,
+    version: 3,
+    events: backfilledEvents,
+  };
+}
+```
+
+This was tempting because:
+
+- The timeline isn't empty on day one for migrating users.
+- Every box "has" a `box_received` event, so downstream code can assume
+  it.
+
+But the timestamps would all be wrong. They'd cluster on whatever date the
+user happened to upgrade the app. Any future analytics — "shakes per
+week," "box-to-empty time," _any_ time-series view — would be poisoned by
+a giant lump of fabricated activity on migration day.
+
+### Option B: Leave the timeline empty
+
+What we actually did (`src/lib/storage.ts:201-207`):
+
+```ts
+if (current.version === 2) {
+  current = {
+    ...current,
+    version: 3,
+    events: [],
+  };
+}
+```
+
+Existing boxes get **no** synthetic events. The timeline starts truly
+empty. From migration day forward, every new box adds a real
+`box_received` event with a real timestamp. Old boxes have no event,
+which downstream code (whenever we write that downstream code) will
+interpret correctly as "pre-timeline; we don't know."
+
+This is a discipline, not a shortcut. The shortcut is to fabricate.
+"Honest absence" is harder to maintain because it requires every future
+consumer of the timeline to handle "this box predates the timeline"
+gracefully. The payoff is that the timeline _means what it says_. A
+`box_received` event at `2026-05-14T13:00:00Z` actually happened then, not
+"some unknown time before that, fudged for convenience."
+
+This is the same instinct as the rule "never insert fake test data into
+production." Provenance matters. Once you put a lie in the database, you
+have to remember forever that it's a lie. Empty data is honest data.
+
+> **General principle:** When migrating to add a historical record, do not
+> backfill with synthetic timestamps. Leave the record empty for
+> pre-migration entities and design downstream consumers to handle the
+> "no entry" case explicitly. False precision is worse than honest
+> absence.
+
+## Why the Timeline Lives Inside `AppState`
+
+The events array is a field on `AppState`. It is stored alongside boxes,
+flavors, the favorite, and settings, in the same LocalStorage key, in the
+same JSON blob, behind the same auto-save subscription. Every event write
+re-serializes and re-persists the entire snapshot.
+
+This is the structural choice that ADR-011's "Alternative 1" considered
+rejecting: a **separate LocalStorage key** for the event log
+(`BROTEINBUDDY_EVENT_LOG`, say). Both options were viable. The reasons for
+co-locating are real, and so are the costs.
+
+### What we got for free by co-locating
+
+- **Backup/restore.** The backup feature serializes `AppState` and
+  deserializes it back through the same `parseBackupJson →
+migrateState → isAppState → replaceAppState` pipeline (see
+  `3.6-json-file-backup-pattern.md`). Because events are _part of_
+  `AppState`, backup files include the timeline automatically. Nothing in
+  `lib/backup.ts` changed. The `isAppState` type guard validates the
+  whole tree including events (`src/types/models.ts:373-396`). Restore
+  installs the whole tree. No special handling for the event log.
+- **Atomic writes.** As argued in the atomic-emission section above, the
+  snapshot and the log advance together because they're one value. If the
+  log lived in a separate key, the store would have to coordinate two
+  writes per action, with all the consistency hazards that implies.
+- **Schema versioning.** One version number on `AppState` governs the
+  whole tree. `migrateState` already chains; adding the event field was
+  one additional `if` block. With a split log, we'd need either a second
+  version number on the log or a coordinated migration across both keys.
+- **Validation.** One type guard (`isAppState`) walks the whole tree. The
+  event log is just `events.every(isAppEvent)`. No new top-level
+  validator, no new boundary.
+
+### What we pay for co-locating
+
+- **Every event write re-serializes the whole snapshot.** Add a single
+  `box_opened` event, and `saveState` serializes all boxes, all flavors,
+  all settings, all events, and writes the whole thing to LocalStorage.
+  For our scale, that's measurably slow only in pathological cases — see
+  ADR-011's "Negative" consequences for the back-of-envelope sizing
+  (~700 KB/year of events at typical use). LocalStorage limits are
+  5–10 MB, so we're fine for years.
+- **The auto-save subscription on `appState` runs on every change.** A
+  burst of events (imagine a stress test or a future bulk import) would
+  cause a burst of full-snapshot writes. We don't debounce.
+
+### When you'd split them
+
+The reasons to extract the log to its own key, in order of likelihood:
+
+1. **Size.** If the event log starts to dominate the snapshot in bytes,
+   re-serializing the snapshot on every event becomes wasteful.
+2. **Write frequency.** If event emission becomes high-frequency (say,
+   tracking every page view or every scroll position — neither of which
+   we plan), the cost per write starts to matter.
+3. **Compaction or windowing.** If we add a rolling window ("keep last 90
+   days of events") or compaction logic, the log starts to want its own
+   lifecycle independent of the snapshot.
+
+The migration to a separate key would be a v4-or-later schema bump:
+introduce `BROTEINBUDDY_EVENT_LOG` as a sibling key, move existing events
+out of `AppState`, leave a stub or just remove the field. The backup
+format would have to change too — likely from a single JSON document to
+either a multi-document file or a `{ "appState": ..., "events": ... }`
+wrapper. None of that is trivial, which is why we punted until there's
+evidence we need to.
+
+> **General principle:** For data that is small, written together, and
+> read together, co-locate. The day the write characteristics diverge —
+> different sizes, different frequencies, different lifecycles — that's
+> when you split. Premature splitting is just as expensive as premature
+> coupling.
+
+## Designed for Sync: PR 2 and PR 3 Live Inside This One
+
+This PR is officially "local-only." No server, no auth, no network. And yet
+several decisions here were made with the next two PRs in mind. It's worth
+calling out which ones, because if you ever come back to this code six
+months from now, the "why is it shaped like this when it could be
+simpler?" answers are mostly here.
+
+### The event log is its own sync primitive
+
+Sync systems generally settle into one of two shapes:
+
+- **State sync.** Server holds the latest state. Clients push their state
+  on every change. Server pushes back the merged state. Conflict
+  resolution is "last write wins" or a CRDT.
+- **Operation sync.** Server holds an ordered log of operations. Clients
+  push their operations. The server orders them globally. Clients replay
+  the merged log to reconstruct state.
+
+The event log is a natural fit for operation sync. Each event is an
+immutable record of "this happened on this device at this time." If two
+devices both emit events while offline, when they reconnect, the server
+can interleave the events into one ordered log without merge conflicts —
+because **events don't conflict with each other**. Two `shake_taken`
+events from two devices is just two shakes. They're additive.
+
+(Snapshot fields _do_ conflict — both devices editing the favorite
+simultaneously is a real conflict. That's why PR 3 is harder than PR 2.
+But the event-log piece doesn't add to that complexity; it actually
+provides a way to _detect_ when snapshot fields drifted, because the log
+tells you what changed on each device.)
+
+### `id` and `timestamp` as sync cursor material
+
+Every event has a stable `id` (`ev_<uuid>`, `src/types/events.ts:39`) and
+a `timestamp` (ISO 8601, `src/types/events.ts:41`). Both are immutable
+once the event is created — `createEvent` sets them and nothing else
+touches them.
+
+This sets up two things for PR 2/3:
+
+- **Idempotent server inserts.** When the client pushes events to the
+  server, the server can use the event `id` as a uniqueness constraint.
+  Push the same event twice (because the network blinked at the wrong
+  moment), get the same row inserted once. The client doesn't have to
+  track which events have been acknowledged with surgical precision; it
+  can re-push the whole queue and trust the server to dedupe.
+- **Sync cursor.** "Give me all events newer than `<timestamp>`" is a
+  trivial query. The client persists the highest timestamp it has
+  successfully synced, and on next connect asks the server for the delta.
+  Lexicographic sort of ISO 8601 strings is chronological sort, so
+  ordering is also free.
+
+If the events had numeric autoincrement IDs (à la SQL), the server would
+have to assign them; the client couldn't synthesize them locally; offline
+emission would be a coordination problem. UUIDs let the client be the
+source of identity, which is exactly what an offline-first app wants.
+
+### Monotonic ISO timestamps (with caveats)
+
+ISO 8601 sorts the same way as chronological time, which is convenient.
+But it's only _per-device_ monotonic, and only as monotonic as
+`Date.now()`. Two events emitted within the same millisecond on the same
+device will have identical timestamps. Two events emitted on two
+different devices, both rapidly, might have indistinguishable timestamps.
+
+For PR 3, this is where vocabulary matters: words like **Lamport
+timestamps** (a logical clock that increments per device per event) and
+**CRDTs** ("conflict-free replicated data types" — data structures
+designed so concurrent edits merge deterministically) will come up. The
+short version of the design space:
+
+- For events specifically, you usually don't need a CRDT. An ordered
+  append-only log of immutable events with idempotent IDs is already
+  conflict-free in the senses that matter (no event is "the wrong order"
+  for replication purposes; the user-visible timeline might want a
+  display order, but that's a UI problem).
+- For snapshot fields like `favoriteFlavorId`, where two devices can
+  legitimately disagree, you have a real conflict to resolve.
+  **Last-write-wins** (the latest device timestamp wins) is the simplest
+  policy and is fine when conflicts are rare and benign. CRDTs are the
+  next step up if last-write-wins is too lossy.
+
+We are not building any of that in this PR. But the event log is now in
+place such that, when PR 2 lands, the server can persist these events
+nearly verbatim (uuid PK, timestamp index, type column, JSONB payload
+column, done), and when PR 3 lands, the offline queue can be implemented
+as "events that haven't been confirmed by the server yet" — a delta on
+top of the log we already have. Nothing in the local schema has to change
+for either of those.
+
+### Why not a UI yet?
+
+There is no "history view" in this PR. No reporting page. No "last
+shake taken at: …" UI element. That's deliberate. The point of PR 1 is to
+get the data captured, with a stable schema, before the design pressure
+of "build a useful timeline visualization" starts shaping what an event
+needs to carry. If we shipped a UI here, future event fields would be
+biased toward "whatever the current UI wants" rather than "whatever the
+event records honestly."
+
+Capture first, display second. The reporting UI is a follow-up that does
+not need a schema change — it just needs to read `$appState.events` and
+render. Backup files already include the timeline, so users with
+historical data can carry it forward even before there's a UI.
+
+## What We Deliberately Did NOT Do
+
+A few specific things were considered and rejected. Listing them so you
+don't have to wonder later whether they were forgotten.
+
+### No `selection_initiated` event
+
+When the user clicks "Random" or "Favorite" or opens the manual flavor
+picker, no event is emitted. Only the _outcome_ (shake taken, suggestion
+rejected, flow cancelled) is recorded.
+
+Why: the timeline would be dominated by initiations that nearly always
+have a corresponding outcome. The signal-to-noise ratio drops.
+`selection_cancelled` already captures the "user backed out" case, so the
+"what flow did they start" question is answerable by looking at the
+`method`/`pool` fields on the cancelled or taken event.
+
+Trivially addable later if the data turns out to be useful for reporting.
+
+### No `box_quantity_adjusted` for manual edits via Inventory
+
+The Inventory page can change a box's quantity directly (e.g., correcting a
+count after a recount). Those edits don't emit events
+(`src/lib/stores.ts:219-247`, see how `updateBoxQuantity` doesn't touch
+the event log). Only the selection-confirm flow's
+`recordShakeTaken` decrements quantity through a recorded event.
+
+Why: manual quantity edits are an administrative action, not a
+user-visible shake event. Conflating them in the timeline would muddy any
+"shakes taken" aggregation. If we ever need to audit corrections, that's
+a different event type (`box_quantity_adjusted` with `previousQuantity`
+and `newQuantity`), which is purely additive and doesn't require a schema
+bump.
+
+### No `box_closed` event
+
+`updateBoxIsOpen` only emits on `false → true` (the open transition,
+`src/lib/stores.ts:328-337`). Closing a box, or toggling open → open,
+produces nothing.
+
+Why: the product question "when did I close this box?" wasn't asked for.
+It's a symmetric addition (`box_closed` event type, emitted in the other
+branch of the same `if`), trivially addable when there's a reason.
+
+### No reporting UI
+
+Already covered above. Capture first.
+
+### No separate event-log LocalStorage key
+
+Already covered. Co-located with the snapshot. Migratable later if needed.
+
+### No throttling, batching, or compaction
+
+Every event triggers a full snapshot write through the auto-save
+subscription. The log grows unbounded. We don't truncate.
+
+Why: at expected scale (~10 events/day), the log will reach ~700 KB after
+a year. LocalStorage limits are 5–10 MB. We have years before this is
+worth optimizing. If it becomes a problem, the solutions in order of
+escalation are (1) debounce auto-save, (2) extract the log to its own
+key, (3) introduce a rolling window or compaction. PR 3 is the natural
+home for any of those because the offline queue introduces the same
+batching concerns.
+
+## Further Reading
+
+- [Martin Fowler: Event Sourcing][fowler-es] — the canonical write-up of
+  the pattern we _didn't_ go all-in on, and why it's still worth
+  understanding. The "snapshot + event log" hybrid we built is sometimes
+  called "event-stream with snapshots."
+- [TypeScript Handbook: Discriminated Unions][ts-discrim] — the language
+  feature that makes `AppEvent` pleasant to consume.
+- [Martin Kleppmann on CRDTs][crdt-paper] — vocabulary for PR 3 conflict
+  resolution. The short version: data structures designed so concurrent
+  edits merge deterministically. You probably won't need them for events
+  (which are naturally conflict-free); you might for snapshot fields like
+  the favorite or the inventory ordering.
+- [Lamport timestamps][lamport] — logical clocks, the next step beyond
+  wall-clock timestamps when you need to order events across devices
+  without a central authority. Probably not needed for this app, but
+  worth knowing exists.
+- ADR-002: Data Model Design — the type-driven approach that motivated
+  per-variant interfaces over a generic shape.
+- ADR-003: LocalStorage Strategy — the migration framework we extended.
+- ADR-010: Backup/Restore Design — the round-trip path that the event
+  log inherits for free.
+- ADR-011: Local Event Timeline — the decision record for this PR. This
+  document elaborates on the "why"; the ADR is the "what was decided."
+- `docs/teaching/1.1-type-driven-design.md` — narrow type guards over
+  runtime schema libraries.
+- `docs/teaching/1.2-web-storage-best-practices.md` — the storage
+  abstraction layer that this PR plugged into.
+- `docs/teaching/1.5-svelte-stores-localstorage.md` — the auto-save
+  subscription that gives us atomic persistence "for free."
+- `docs/teaching/3.6-json-file-backup-pattern.md` — the pipeline the
+  event log rides through on backup/restore, and the "tagged errors over
+  class hierarchies" argument that applies equally to event variants.
+
+[fowler-es]: https://martinfowler.com/eaaDev/EventSourcing.html
+[ts-discrim]: https://www.typescriptlang.org/docs/handbook/2/narrowing.html#discriminated-unions
+[crdt-paper]: https://crdt.tech/
+[lamport]: https://lamport.azurewebsites.net/pubs/time-clocks.pdf

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -1,0 +1,46 @@
+/**
+ * Pure factories for building {@link AppEvent} records.
+ *
+ * Separated from the store so events can be constructed and tested without
+ * pulling in Svelte / LocalStorage dependencies. The store imports
+ * {@link createEvent} and appends the result to `state.events`.
+ *
+ * @module lib/events
+ */
+
+import type { AppEvent, AppEventType } from '../types/events';
+
+/** Variant of {@link AppEvent} that has the discriminator `type`. */
+type EventOf<T extends AppEventType> = Extract<AppEvent, { type: T }>;
+
+/** The variant-specific payload — everything except the base fields. */
+type EventPayload<T extends AppEventType> = Omit<EventOf<T>, 'id' | 'timestamp' | 'type'>;
+
+/**
+ * Builds an {@link AppEvent} of the requested type, filling in a fresh id and
+ * the current timestamp.
+ *
+ * Uses `crypto.randomUUID()` (matches `lib/utils/id.ts`) and
+ * `new Date().toISOString()`. The factory is deterministic given mocked time
+ * and uuid sources, which keeps the unit tests stable.
+ *
+ * @param type - The event variant to construct
+ * @param payload - Variant-specific fields (no id, timestamp, or type)
+ * @returns A fully-formed event ready to append to the timeline
+ *
+ * @example
+ * const ev = createEvent('shake_taken', {
+ *   boxId: 'box_123',
+ *   flavorId: 'flavor_chocolate',
+ *   method: 'random',
+ *   pool: 'caffeinated',
+ * });
+ */
+export function createEvent<T extends AppEventType>(type: T, payload: EventPayload<T>): EventOf<T> {
+  return {
+    id: `ev_${crypto.randomUUID()}`,
+    timestamp: new Date().toISOString(),
+    type,
+    ...payload,
+  } as EventOf<T>;
+}

--- a/src/lib/navigation-state.ts
+++ b/src/lib/navigation-state.ts
@@ -9,6 +9,7 @@
 
 import { writable } from 'svelte/store';
 import type { RandomPool } from '../types/models';
+import type { EventMethod } from '../types/events';
 
 /**
  * The flavor ID selected for the random confirmation flow.
@@ -23,10 +24,19 @@ export const selectedFlavorId = writable<string | null>(null);
 export const selectedPool = writable<RandomPool | null>(null);
 
 /**
+ * How the current selection flow was initiated.
+ * Set by Home.svelte on each entry path; read by RandomConfirm.svelte when
+ * emitting timeline events so the recorded `method` matches the user's intent
+ * (random / manual / favorite). null between flows.
+ */
+export const selectedMethod = writable<EventMethod | null>(null);
+
+/**
  * Clear all navigation state. Call after consuming the state
  * or when navigating away without consuming.
  */
 export function clearNavigationState(): void {
   selectedFlavorId.set(null);
   selectedPool.set(null);
+  selectedMethod.set(null);
 }

--- a/src/lib/sample-data.ts
+++ b/src/lib/sample-data.ts
@@ -46,7 +46,7 @@ import type { AppState } from '../types/models';
  */
 export function generateSampleData(): AppState {
   return {
-    version: 2,
+    version: 3,
 
     flavors: [
       {
@@ -142,5 +142,7 @@ export function generateSampleData(): AppState {
     favoriteFlavorId: 'chocolate', // Set favorite for quick-pick demonstration
 
     settings: {}, // Empty in v1
+
+    events: [], // Sample data starts with an empty timeline
   };
 }

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -156,37 +156,55 @@ export function clearState(): void {
  * data model changes (e.g., new fields added, old fields removed), this
  * function transforms old data to match the current schema.
  *
+ * Migrations are chained: a v1 payload runs through v1→v2 then v2→v3 in a
+ * single call. The function is idempotent — a payload already at the current
+ * version is returned unchanged.
+ *
  * @param data - Raw data loaded from localStorage (unknown type)
  * @returns Migrated data compatible with current schema
  *
  * @remarks
- * Current schema version: 2
+ * Current schema version: 3
+ *
  * Migration path:
  * - Version 1 → 2: Replace `excludeFromRandom: boolean` with `randomPool: RandomPool | null`
  *   - `excludeFromRandom: false` → `randomPool: 'caffeine-free'`
  *   - `excludeFromRandom: true` → `randomPool: null`
+ * - Version 2 → 3: Add empty `events: []` timeline. Existing boxes are
+ *   not backfilled with synthetic `box_received` events because their true
+ *   receive dates are unknown.
  */
 export function migrateState(data: unknown): unknown {
-  if (typeof data === 'object' && data !== null && 'version' in data) {
-    const versioned = data as { version: number; flavors?: unknown[] };
-
-    if (versioned.version === 1 && Array.isArray(versioned.flavors)) {
-      const migratedFlavors = versioned.flavors.map((f: unknown) => {
-        const flavor = f as Record<string, unknown>;
-        const { excludeFromRandom, ...rest } = flavor;
-        return {
-          ...rest,
-          randomPool: excludeFromRandom ? null : 'caffeine-free',
-        };
-      });
-
-      return {
-        ...versioned,
-        version: 2,
-        flavors: migratedFlavors,
-      };
-    }
+  if (typeof data !== 'object' || data === null || !('version' in data)) {
+    return data;
   }
 
-  return data;
+  let current = data as Record<string, unknown> & { version: number };
+
+  if (current.version === 1 && Array.isArray(current.flavors)) {
+    const migratedFlavors = current.flavors.map((f: unknown) => {
+      const flavor = f as Record<string, unknown>;
+      const { excludeFromRandom, ...rest } = flavor;
+      return {
+        ...rest,
+        randomPool: excludeFromRandom ? null : 'caffeine-free',
+      };
+    });
+
+    current = {
+      ...current,
+      version: 2,
+      flavors: migratedFlavors,
+    };
+  }
+
+  if (current.version === 2) {
+    current = {
+      ...current,
+      version: 3,
+      events: [],
+    };
+  }
+
+  return current;
 }

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -11,6 +11,8 @@
 import { writable, type Writable } from 'svelte/store';
 import { loadState, saveState } from './storage';
 import { isAppState, type AppState, type Box, type Flavor, type Location } from '../types/models';
+import type { AppEvent, EventMethod, EventPool } from '../types/events';
+import { createEvent } from './events';
 
 /**
  * Creates the application state store with auto-save functionality.
@@ -141,10 +143,18 @@ export function addBox(box: Box): void {
       throw new Error(`Box with ID "${box.id}" already exists`);
     }
 
-    // Create new state with box added
+    const event = createEvent('box_received', {
+      boxId: box.id,
+      flavorId: box.flavorId,
+      quantity: box.quantity,
+      location: box.location,
+      isOpen: box.isOpen,
+    });
+
     return {
       ...state,
       boxes: [...state.boxes, box],
+      events: [...state.events, event],
     };
   });
 }
@@ -173,10 +183,16 @@ export function removeBox(boxId: string): void {
       throw new Error(`Box with ID "${boxId}" not found`);
     }
 
-    // Create new state with box removed
+    const event = createEvent('box_removed', {
+      boxId: box.id,
+      flavorId: box.flavorId,
+      finalQuantity: box.quantity,
+    });
+
     return {
       ...state,
       boxes: state.boxes.filter((b) => b.id !== boxId),
+      events: [...state.events, event],
     };
   });
 }
@@ -298,16 +314,32 @@ export function updateBoxIsOpen(boxId: string, isOpen: boolean): void {
       throw new Error(`Box with ID "${boxId}" not found`);
     }
 
+    const previousBox = state.boxes[boxIndex];
+
     // Create new state with updated box
     const updatedBoxes = [...state.boxes];
     updatedBoxes[boxIndex] = {
-      ...updatedBoxes[boxIndex],
+      ...previousBox,
       isOpen,
     };
+
+    // Only emit `box_opened` on the false → true transition. Closing a box
+    // or toggling true → true produces no event.
+    const newEvents =
+      isOpen && !previousBox.isOpen
+        ? [
+            ...state.events,
+            createEvent('box_opened', {
+              boxId: previousBox.id,
+              flavorId: previousBox.flavorId,
+            }),
+          ]
+        : state.events;
 
     return {
       ...state,
       boxes: updatedBoxes,
+      events: newEvents,
     };
   });
 }
@@ -428,5 +460,106 @@ export function setFavoriteFlavor(flavorId: string | null): void {
   appState.update((state) => ({
     ...state,
     favoriteFlavorId: flavorId,
+  }));
+}
+
+/**
+ * Atomically decrements the quantity of a box and records a `shake_taken`
+ * event capturing how the shake was chosen.
+ *
+ * This is the single entry point for "the user took a shake" — the selection
+ * flow calls this instead of `updateBoxQuantity`, so the quantity change and
+ * the timeline event are committed in one store update.
+ *
+ * @param opts - Box, flavor, and selection-method context
+ * @throws {Error} If the box is not found or already at zero
+ */
+export function recordShakeTaken(opts: {
+  boxId: string;
+  flavorId: string;
+  method: EventMethod;
+  pool: EventPool;
+}): void {
+  appState.update((state) => {
+    const boxIndex = state.boxes.findIndex((b) => b.id === opts.boxId);
+    if (boxIndex === -1) {
+      throw new Error(`Box with ID "${opts.boxId}" not found`);
+    }
+
+    const previousBox = state.boxes[boxIndex];
+    if (previousBox.quantity <= 0) {
+      throw new Error(`Cannot take a shake from empty box "${opts.boxId}"`);
+    }
+
+    const updatedBoxes = [...state.boxes];
+    updatedBoxes[boxIndex] = {
+      ...previousBox,
+      quantity: previousBox.quantity - 1,
+    };
+
+    const event = createEvent('shake_taken', {
+      boxId: opts.boxId,
+      flavorId: opts.flavorId,
+      method: opts.method,
+      pool: opts.pool,
+    });
+
+    return {
+      ...state,
+      boxes: updatedBoxes,
+      events: [...state.events, event],
+    };
+  });
+}
+
+/**
+ * Records that the user rejected a suggested flavor by clicking
+ * "Different Choice" on the confirm screen. No box state changes; only the
+ * timeline gains an entry.
+ */
+export function recordShakeRejected(opts: {
+  rejectedFlavorId: string;
+  method: EventMethod;
+  pool: EventPool;
+}): void {
+  appendEvent(
+    createEvent('shake_rejected', {
+      rejectedFlavorId: opts.rejectedFlavorId,
+      method: opts.method,
+      pool: opts.pool,
+    })
+  );
+}
+
+/**
+ * Records that the user cancelled out of a selection flow without taking a
+ * shake. No box state changes; only the timeline gains an entry.
+ */
+export function recordSelectionCancelled(opts: {
+  flavorId: string | null;
+  method: EventMethod;
+  pool: EventPool;
+}): void {
+  appendEvent(
+    createEvent('selection_cancelled', {
+      flavorId: opts.flavorId,
+      method: opts.method,
+      pool: opts.pool,
+    })
+  );
+}
+
+/**
+ * Internal helper: appends one event to the timeline.
+ *
+ * Use this for actions that only need to record a timeline entry without
+ * touching boxes or flavors. Mutations that change both state and the
+ * timeline should build their event inside the same `appState.update` call
+ * to keep the write atomic.
+ */
+function appendEvent(event: AppEvent): void {
+  appState.update((state) => ({
+    ...state,
+    events: [...state.events, event],
   }));
 }

--- a/src/routes/Home.svelte
+++ b/src/routes/Home.svelte
@@ -14,7 +14,7 @@
   import { push } from 'svelte-spa-router';
   import { ROUTES } from '$lib/router/routes';
   import { appState } from '$lib/stores';
-  import { selectedFlavorId, selectedPool } from '$lib/navigation-state';
+  import { selectedFlavorId, selectedPool, selectedMethod } from '$lib/navigation-state';
   import { maybeGetFlavor } from '$lib/utils/flavor';
   import type { Flavor, RandomPool } from '../types/models';
 
@@ -42,6 +42,7 @@
    */
   function handleRandomClick(pool: RandomPool) {
     selectedPool.set(pool);
+    selectedMethod.set('random');
     push(ROUTES.RANDOM);
   }
 
@@ -52,6 +53,8 @@
   function handleFavoriteClick() {
     if (favoriteFlavor) {
       selectedFlavorId.set(favoriteFlavor.id);
+      selectedPool.set(null);
+      selectedMethod.set('favorite');
       push(ROUTES.RANDOM_CONFIRM);
     }
   }
@@ -69,6 +72,8 @@
    */
   function handleFlavorSelect(flavor: Flavor) {
     selectedFlavorId.set(flavor.id);
+    selectedPool.set(null);
+    selectedMethod.set('manual');
     showFlavorPicker = false;
     push(ROUTES.RANDOM_CONFIRM);
   }

--- a/src/routes/RandomConfirm.svelte
+++ b/src/routes/RandomConfirm.svelte
@@ -12,14 +12,22 @@
   import Button from '$lib/components/Button.svelte';
   import { push } from 'svelte-spa-router';
   import { ROUTES } from '$lib/router/routes';
-  import { appState, updateBoxQuantity } from '$lib/stores';
+  import {
+    appState,
+    recordShakeTaken,
+    recordShakeRejected,
+    recordSelectionCancelled,
+  } from '$lib/stores';
   import { selectPriorityBox, compareBoxPriority } from '$lib/box-selection';
   import {
     selectedFlavorId as selectedFlavorIdStore,
+    selectedPool as selectedPoolStore,
+    selectedMethod as selectedMethodStore,
     clearNavigationState,
   } from '$lib/navigation-state';
   import { maybeGetFlavor } from '$lib/utils/flavor';
   import type { Flavor, Box } from '../types/models';
+  import type { EventMethod, EventPool } from '../types/events';
   import { get } from 'svelte/store';
   import { onMount } from 'svelte';
 
@@ -29,6 +37,15 @@
   let selectedFlavorId = $state<string | null>(null);
   let selectedFlavor = $state<Flavor | null>(null);
   let sessionErrorMessage = $state<string | null>(null);
+
+  /**
+   * Selection method and pool snapshotted from navigation state on mount.
+   * Captured here (rather than read fresh on each click) so the timeline
+   * event records the method that brought the user to this screen — even if
+   * the user navigates away and back.
+   */
+  let selectionMethod = $state<EventMethod>('random');
+  let selectionPool = $state<EventPool>(null);
 
   // Reactive derived values that automatically update when store changes
   let priorityBox = $derived.by(() => {
@@ -74,6 +91,11 @@
       return;
     }
 
+    // Snapshot selection context for the timeline event. Default to 'random'
+    // for any direct navigation that bypassed Home.svelte's setters.
+    selectionMethod = get(selectedMethodStore) ?? 'random';
+    selectionPool = get(selectedPoolStore);
+
     // No manual refresh needed - derived values automatically compute on first render
   });
 
@@ -85,13 +107,17 @@
   }
 
   /**
-   * Confirm selection: decrement quantity and go home
+   * Confirm selection: decrement quantity, record event, and go home
    */
   function handleConfirm() {
-    if (!priorityBox) return;
+    if (!priorityBox || !selectedFlavorId) return;
 
-    const newQuantity = priorityBox.quantity - 1;
-    updateBoxQuantity(priorityBox.id, newQuantity);
+    recordShakeTaken({
+      boxId: priorityBox.id,
+      flavorId: selectedFlavorId,
+      method: selectionMethod,
+      pool: selectionPool,
+    });
 
     // Clear navigation state
     clearNavigationState();
@@ -104,6 +130,12 @@
    * Cancel: go back to home without changes
    */
   function handleCancel() {
+    recordSelectionCancelled({
+      flavorId: selectedFlavorId,
+      method: selectionMethod,
+      pool: selectionPool,
+    });
+
     // Clear navigation state
     clearNavigationState();
 
@@ -115,10 +147,14 @@
    * Add Another: decrement quantity again and stay on this screen
    */
   function handleAddAnother() {
-    if (!priorityBox) return;
+    if (!priorityBox || !selectedFlavorId) return;
 
-    const newQuantity = priorityBox.quantity - 1;
-    updateBoxQuantity(priorityBox.id, newQuantity);
+    recordShakeTaken({
+      boxId: priorityBox.id,
+      flavorId: selectedFlavorId,
+      method: selectionMethod,
+      pool: selectionPool,
+    });
 
     // No manual refresh needed - derived values automatically update!
   }
@@ -131,7 +167,14 @@
 
     const flavorIdToExclude = selectedFlavorId;
 
-    // Clear flavor selection but preserve selectedPool for the re-roll
+    recordShakeRejected({
+      rejectedFlavorId: flavorIdToExclude,
+      method: selectionMethod,
+      pool: selectionPool,
+    });
+
+    // Clear flavor selection but preserve selectedPool / selectedMethod
+    // for the re-roll (the user is still in the same random flow).
     selectedFlavorIdStore.set(null);
 
     // Navigate to random with exclude parameter

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -1,0 +1,199 @@
+/**
+ * Event timeline data model for BroteinBuddy.
+ *
+ * Events are append-only records of user-visible actions: boxes received,
+ * boxes opened, shakes taken (with selection method), and "no-transaction"
+ * moments like clicking "Different Choice" or "Cancel".
+ *
+ * The event log lives inside {@link AppState} as `events: AppEvent[]` and is
+ * persisted via the standard LocalStorage save path. Each event is immutable
+ * once created.
+ *
+ * @module types/events
+ */
+
+import { isLocation, type Location } from './models';
+
+/**
+ * How a flavor was chosen for a selection.
+ *
+ * - `'random'`: Weighted random pick from a pool (caffeinated or caffeine-free)
+ * - `'manual'`: User picked the flavor from the choose-flavor modal
+ * - `'favorite'`: User pressed the favorite-flavor quick-pick button
+ */
+export type EventMethod = 'random' | 'manual' | 'favorite';
+
+/**
+ * Which random pool was active for a selection, or null when the path doesn't
+ * involve a pool (manual / favorite).
+ *
+ * Matches {@link RandomPool} from `models.ts` with `null` added.
+ */
+export type EventPool = 'caffeinated' | 'caffeine-free' | null;
+
+/**
+ * Fields common to every {@link AppEvent} variant.
+ */
+interface AppEventBase {
+  /** Unique event ID, format `ev_<uuid>` */
+  id: string;
+  /** ISO 8601 timestamp (e.g. `2026-05-14T15:23:11.245Z`) */
+  timestamp: string;
+}
+
+/** A box was added to inventory. */
+export interface BoxReceivedEvent extends AppEventBase {
+  type: 'box_received';
+  boxId: string;
+  flavorId: string;
+  quantity: number;
+  location: Location;
+  isOpen: boolean;
+}
+
+/** A previously-sealed box transitioned to open. */
+export interface BoxOpenedEvent extends AppEventBase {
+  type: 'box_opened';
+  boxId: string;
+  flavorId: string;
+}
+
+/** A box was deleted from inventory. */
+export interface BoxRemovedEvent extends AppEventBase {
+  type: 'box_removed';
+  boxId: string;
+  flavorId: string;
+  finalQuantity: number;
+}
+
+/** A shake was confirmed and the box quantity decremented. */
+export interface ShakeTakenEvent extends AppEventBase {
+  type: 'shake_taken';
+  boxId: string;
+  flavorId: string;
+  method: EventMethod;
+  pool: EventPool;
+}
+
+/** The user clicked "Different Choice" instead of confirming a suggestion. */
+export interface ShakeRejectedEvent extends AppEventBase {
+  type: 'shake_rejected';
+  rejectedFlavorId: string;
+  method: EventMethod;
+  pool: EventPool;
+}
+
+/** The user cancelled out of the confirm screen without taking a shake. */
+export interface SelectionCancelledEvent extends AppEventBase {
+  type: 'selection_cancelled';
+  flavorId: string | null;
+  method: EventMethod;
+  pool: EventPool;
+}
+
+/**
+ * Discriminated union of every event type the application records.
+ *
+ * Add a new variant by:
+ *   1. Defining the interface above with a unique `type` literal.
+ *   2. Adding it to this union.
+ *   3. Extending {@link isAppEvent} with a guard branch.
+ *   4. Emitting it from the relevant store action.
+ *
+ * Existing variants are stable; do not change their shape without a schema
+ * version bump and migration.
+ */
+export type AppEvent =
+  | BoxReceivedEvent
+  | BoxOpenedEvent
+  | BoxRemovedEvent
+  | ShakeTakenEvent
+  | ShakeRejectedEvent
+  | SelectionCancelledEvent;
+
+/** All valid `type` discriminator values for {@link AppEvent}. */
+export type AppEventType = AppEvent['type'];
+
+const EVENT_METHODS: readonly EventMethod[] = ['random', 'manual', 'favorite'];
+
+function isEventMethod(value: unknown): value is EventMethod {
+  return typeof value === 'string' && (EVENT_METHODS as readonly string[]).includes(value);
+}
+
+function isEventPool(value: unknown): value is EventPool {
+  return value === 'caffeinated' || value === 'caffeine-free' || value === null;
+}
+
+function hasBaseFields(value: Record<string, unknown>): boolean {
+  return (
+    typeof value.id === 'string' &&
+    value.id.length > 0 &&
+    typeof value.timestamp === 'string' &&
+    value.timestamp.length > 0
+  );
+}
+
+/**
+ * Type guard for the {@link AppEvent} discriminated union.
+ *
+ * Validates the shared base fields plus the variant-specific payload. Used by
+ * the AppState schema validator so corrupted events in storage are rejected
+ * before they reach the UI.
+ *
+ * @param value - The value to check
+ * @returns true if value is a valid AppEvent
+ */
+export function isAppEvent(value: unknown): value is AppEvent {
+  if (typeof value !== 'object' || value === null) return false;
+  const v = value as Record<string, unknown>;
+
+  if (!hasBaseFields(v)) return false;
+
+  switch (v.type) {
+    case 'box_received':
+      return (
+        typeof v.boxId === 'string' &&
+        typeof v.flavorId === 'string' &&
+        typeof v.quantity === 'number' &&
+        Number.isInteger(v.quantity) &&
+        v.quantity >= 0 &&
+        typeof v.isOpen === 'boolean' &&
+        isLocation(v.location)
+      );
+
+    case 'box_opened':
+      return typeof v.boxId === 'string' && typeof v.flavorId === 'string';
+
+    case 'box_removed':
+      return (
+        typeof v.boxId === 'string' &&
+        typeof v.flavorId === 'string' &&
+        typeof v.finalQuantity === 'number' &&
+        Number.isInteger(v.finalQuantity) &&
+        v.finalQuantity >= 0
+      );
+
+    case 'shake_taken':
+      return (
+        typeof v.boxId === 'string' &&
+        typeof v.flavorId === 'string' &&
+        isEventMethod(v.method) &&
+        isEventPool(v.pool)
+      );
+
+    case 'shake_rejected':
+      return (
+        typeof v.rejectedFlavorId === 'string' && isEventMethod(v.method) && isEventPool(v.pool)
+      );
+
+    case 'selection_cancelled':
+      return (
+        (v.flavorId === null || typeof v.flavorId === 'string') &&
+        isEventMethod(v.method) &&
+        isEventPool(v.pool)
+      );
+
+    default:
+      return false;
+  }
+}

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -7,6 +7,8 @@
  * @module types/models
  */
 
+import { isAppEvent, type AppEvent } from './events';
+
 /**
  * Represents a 2D coordinate position in the physical storage system.
  *
@@ -172,11 +174,12 @@ export interface Settings {
  * @example
  * ```typescript
  * const initialState: AppState = {
- *   version: 1,
+ *   version: 3,
  *   boxes: [],
  *   flavors: [],
  *   favoriteFlavorId: null,
- *   settings: {}
+ *   settings: {},
+ *   events: []
  * };
  * ```
  *
@@ -185,13 +188,13 @@ export interface Settings {
  * - Schema version enables graceful migrations when structure changes
  * - All references between objects use IDs (normalized structure)
  * - favoriteFlavorId enables quick-pick functionality from home screen
- * - Current version is 1 (initial schema)
+ * - Current version is 3 (adds append-only `events` timeline)
  */
 export interface AppState {
   /**
    * Schema version number for migration support.
    * Increment when making breaking changes to the data structure.
-   * Current version: 2
+   * Current version: 3
    */
   version: number;
 
@@ -209,6 +212,14 @@ export interface AppState {
 
   /** Application-wide settings and preferences */
   settings: Settings;
+
+  /**
+   * Append-only timeline of user-visible actions: box lifecycle events,
+   * shake selections, and "no-transaction" moments (rejected suggestions,
+   * cancellations). Ordered by emission, which matches `timestamp` ordering
+   * in normal operation.
+   */
+  events: AppEvent[];
 }
 
 /**
@@ -368,6 +379,7 @@ export function isAppState(value: unknown): value is AppState {
     'flavors' in value &&
     'favoriteFlavorId' in value &&
     'settings' in value &&
+    'events' in value &&
     typeof (value as AppState).version === 'number' &&
     (value as AppState).version >= 1 &&
     Number.isInteger((value as AppState).version) &&
@@ -378,7 +390,9 @@ export function isAppState(value: unknown): value is AppState {
     ((value as AppState).favoriteFlavorId === null ||
       typeof (value as AppState).favoriteFlavorId === 'string') &&
     typeof (value as AppState).settings === 'object' &&
-    (value as AppState).settings !== null
+    (value as AppState).settings !== null &&
+    Array.isArray((value as AppState).events) &&
+    (value as AppState).events.every(isAppEvent)
   );
 }
 
@@ -390,10 +404,11 @@ export function isAppState(value: unknown): value is AppState {
  */
 export function createDefaultAppState(): AppState {
   return {
-    version: 2,
+    version: 3,
     boxes: [],
     flavors: [],
     favoriteFlavorId: null,
     settings: {},
+    events: [],
   };
 }

--- a/tests/e2e/backup-restore.spec.ts
+++ b/tests/e2e/backup-restore.spec.ts
@@ -105,9 +105,11 @@ test.describe('Backup & Restore', () => {
     const text = Buffer.concat(chunks).toString('utf-8');
     const parsed = JSON.parse(text) as AppState;
 
-    expect(parsed.version).toBe(2);
+    expect(parsed.version).toBe(3);
     expect(parsed.boxes).toHaveLength(1);
     expect(parsed.flavors[0].name).toBe('Chocolate');
+    expect(parsed.events).toBeDefined();
+    expect(Array.isArray(parsed.events)).toBe(true);
   });
 
   test('restores a backup file and replaces existing data', async ({ page }) => {

--- a/tests/e2e/random-flow.spec.ts
+++ b/tests/e2e/random-flow.spec.ts
@@ -264,13 +264,20 @@ test.describe('Random Selection Flow', () => {
       // Should return to home
       await expect(page).toHaveURL(/#\/$/);
 
-      // Verify state was NOT updated
+      // Verify inventory was NOT updated (cancel still records a timeline
+      // event, so the full state is intentionally not byte-equal).
       const updatedState = await page.evaluate((key) => {
         const stored = localStorage.getItem(key);
         return stored ? JSON.parse(stored) : null;
       }, STORAGE_KEY);
 
-      expect(JSON.stringify(updatedState)).toBe(JSON.stringify(initialState));
+      expect(updatedState.boxes).toEqual(initialState.boxes);
+      expect(updatedState.flavors).toEqual(initialState.flavors);
+      expect(updatedState.favoriteFlavorId).toEqual(initialState.favoriteFlavorId);
+
+      const newEvents = updatedState.events.slice(initialState.events.length);
+      expect(newEvents).toHaveLength(1);
+      expect(newEvents[0].type).toBe('selection_cancelled');
     });
   });
 

--- a/tests/e2e/random-flow.spec.ts
+++ b/tests/e2e/random-flow.spec.ts
@@ -220,6 +220,30 @@ test.describe('Random Selection Flow', () => {
 
       expect(updatedTotalQuantity).toBe(initialTotalQuantity - 1);
     });
+
+    test('records a shake_taken event in the timeline', async ({ page }) => {
+      await page.getByTestId('random-caffeine-free-button').click();
+      await expect(page).toHaveURL(/#\/random\/confirm/, { timeout: 3000 });
+
+      await page.locator('button').filter({ hasText: 'Confirm' }).click();
+      await expect(page).toHaveURL(/#\/$/);
+
+      const after = await page.evaluate((key) => {
+        const stored = localStorage.getItem(key);
+        return stored ? JSON.parse(stored) : null;
+      }, STORAGE_KEY);
+
+      expect(after.version).toBe(3);
+      expect(Array.isArray(after.events)).toBe(true);
+
+      const shakeTaken = after.events.find((e: { type: string }) => e.type === 'shake_taken');
+      expect(shakeTaken).toBeDefined();
+      expect(shakeTaken.method).toBe('random');
+      expect(shakeTaken.pool).toBe('caffeine-free');
+      expect(typeof shakeTaken.boxId).toBe('string');
+      expect(typeof shakeTaken.flavorId).toBe('string');
+      expect(typeof shakeTaken.timestamp).toBe('string');
+    });
   });
 
   test.describe('Cancel Action', () => {

--- a/tests/unit/backup.test.ts
+++ b/tests/unit/backup.test.ts
@@ -15,7 +15,7 @@ import {
 import { createDefaultAppState, type AppState } from '../../src/types/models';
 
 const sampleState: AppState = {
-  version: 2,
+  version: 3,
   boxes: [
     {
       id: 'box1',
@@ -38,6 +38,35 @@ const sampleState: AppState = {
   ],
   favoriteFlavorId: 'flavor1',
   settings: {},
+  events: [
+    {
+      id: 'ev_received_1',
+      timestamp: '2026-05-01T08:30:00.000Z',
+      type: 'box_received',
+      boxId: 'box1',
+      flavorId: 'flavor1',
+      quantity: 12,
+      location: { stack: 1, height: 0 },
+      isOpen: false,
+    },
+    {
+      id: 'ev_taken_1',
+      timestamp: '2026-05-02T14:15:00.000Z',
+      type: 'shake_taken',
+      boxId: 'box1',
+      flavorId: 'flavor1',
+      method: 'random',
+      pool: 'caffeinated',
+    },
+    {
+      id: 'ev_rejected_1',
+      timestamp: '2026-05-03T09:00:00.000Z',
+      type: 'shake_rejected',
+      rejectedFlavorId: 'flavor2',
+      method: 'random',
+      pool: 'caffeine-free',
+    },
+  ],
 };
 
 describe('exportStateAsJson', () => {
@@ -80,11 +109,37 @@ describe('parseBackupJson', () => {
 
     const result = parseBackupJson(v1Backup);
 
-    expect(result.version).toBe(2);
+    expect(result.version).toBe(3);
     expect(result.flavors).toEqual([
       { id: 'flavor1', name: 'Chocolate', randomPool: 'caffeine-free' },
       { id: 'flavor2', name: 'Vanilla', randomPool: null },
     ]);
+    expect(result.events).toEqual([]);
+  });
+
+  it('upgrades a v2 backup (no events field) to v3 with an empty events array', () => {
+    const v2Backup = JSON.stringify({
+      version: 2,
+      boxes: [
+        {
+          id: 'box1',
+          flavorId: 'flavor1',
+          quantity: 12,
+          location: { stack: 0, height: 0 },
+          isOpen: false,
+        },
+      ],
+      flavors: [{ id: 'flavor1', name: 'Chocolate', randomPool: 'caffeinated' }],
+      favoriteFlavorId: 'flavor1',
+      settings: {},
+    });
+
+    const result = parseBackupJson(v2Backup);
+
+    expect(result.version).toBe(3);
+    expect(result.events).toEqual([]);
+    expect(result.boxes).toHaveLength(1);
+    expect(result.favoriteFlavorId).toBe('flavor1');
   });
 
   it('throws BackupError(empty) on empty input', () => {

--- a/tests/unit/components/WelcomeModal.test.ts
+++ b/tests/unit/components/WelcomeModal.test.ts
@@ -103,11 +103,12 @@ describe.skip('WelcomeModal', () => {
 
     it('should save generated sample data to storage', async () => {
       const mockSampleData = {
-        version: 1,
-        flavors: [{ id: 'test', name: 'Test', randomPool: 'caffeine-free' }],
+        version: 3,
+        flavors: [{ id: 'test', name: 'Test', randomPool: 'caffeine-free' as const }],
         boxes: [],
         favoriteFlavorId: null,
         settings: {},
+        events: [],
       };
       vi.spyOn(sampleData, 'generateSampleData').mockReturnValue(mockSampleData);
       const saveSpy = vi.spyOn(storage, 'saveState');

--- a/tests/unit/events.test.ts
+++ b/tests/unit/events.test.ts
@@ -1,0 +1,342 @@
+/**
+ * Unit tests for the event timeline data model + factory.
+ *
+ * Covers `isAppEvent` (all six variants, positive + negative cases) and
+ * `createEvent` (id format, timestamp shape, payload pass-through).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createEvent } from '../../src/lib/events';
+import { isAppEvent } from '../../src/types/events';
+
+describe('createEvent', () => {
+  it('produces an id with the `ev_` prefix', () => {
+    const ev = createEvent('box_opened', { boxId: 'b1', flavorId: 'f1' });
+    expect(ev.id).toMatch(/^ev_/);
+  });
+
+  it('produces an ISO 8601 timestamp', () => {
+    const ev = createEvent('box_opened', { boxId: 'b1', flavorId: 'f1' });
+    expect(ev.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+    expect(new Date(ev.timestamp).toISOString()).toBe(ev.timestamp);
+  });
+
+  it('sets the type discriminator from the first arg', () => {
+    const ev = createEvent('selection_cancelled', {
+      flavorId: 'f1',
+      method: 'manual',
+      pool: null,
+    });
+    expect(ev.type).toBe('selection_cancelled');
+  });
+
+  it('passes through box_received payload fields verbatim', () => {
+    const ev = createEvent('box_received', {
+      boxId: 'b1',
+      flavorId: 'f1',
+      quantity: 12,
+      location: { stack: 2, height: 1 },
+      isOpen: false,
+    });
+    expect(ev.boxId).toBe('b1');
+    expect(ev.flavorId).toBe('f1');
+    expect(ev.quantity).toBe(12);
+    expect(ev.location).toEqual({ stack: 2, height: 1 });
+    expect(ev.isOpen).toBe(false);
+  });
+
+  it('passes through shake_taken payload fields verbatim', () => {
+    const ev = createEvent('shake_taken', {
+      boxId: 'b1',
+      flavorId: 'f1',
+      method: 'random',
+      pool: 'caffeinated',
+    });
+    expect(ev.method).toBe('random');
+    expect(ev.pool).toBe('caffeinated');
+  });
+
+  it('passes through selection_cancelled with null flavorId', () => {
+    const ev = createEvent('selection_cancelled', {
+      flavorId: null,
+      method: 'random',
+      pool: 'caffeine-free',
+    });
+    expect(ev.flavorId).toBeNull();
+  });
+
+  it('generates unique ids across calls', () => {
+    const a = createEvent('box_opened', { boxId: 'b1', flavorId: 'f1' });
+    const b = createEvent('box_opened', { boxId: 'b1', flavorId: 'f1' });
+    expect(a.id).not.toBe(b.id);
+  });
+
+  it('produces events that pass isAppEvent', () => {
+    expect(
+      isAppEvent(
+        createEvent('box_received', {
+          boxId: 'b1',
+          flavorId: 'f1',
+          quantity: 1,
+          location: { stack: 0, height: 0 },
+          isOpen: false,
+        })
+      )
+    ).toBe(true);
+    expect(isAppEvent(createEvent('box_opened', { boxId: 'b1', flavorId: 'f1' }))).toBe(true);
+    expect(
+      isAppEvent(createEvent('box_removed', { boxId: 'b1', flavorId: 'f1', finalQuantity: 0 }))
+    ).toBe(true);
+    expect(
+      isAppEvent(
+        createEvent('shake_taken', {
+          boxId: 'b1',
+          flavorId: 'f1',
+          method: 'random',
+          pool: 'caffeinated',
+        })
+      )
+    ).toBe(true);
+    expect(
+      isAppEvent(
+        createEvent('shake_rejected', {
+          rejectedFlavorId: 'f1',
+          method: 'random',
+          pool: 'caffeine-free',
+        })
+      )
+    ).toBe(true);
+    expect(
+      isAppEvent(
+        createEvent('selection_cancelled', {
+          flavorId: null,
+          method: 'favorite',
+          pool: null,
+        })
+      )
+    ).toBe(true);
+  });
+});
+
+describe('isAppEvent — positive cases', () => {
+  it('accepts a valid box_received event', () => {
+    expect(
+      isAppEvent({
+        id: 'ev_1',
+        timestamp: '2026-05-14T12:00:00.000Z',
+        type: 'box_received',
+        boxId: 'b1',
+        flavorId: 'f1',
+        quantity: 12,
+        location: { stack: 0, height: 0 },
+        isOpen: false,
+      })
+    ).toBe(true);
+  });
+
+  it('accepts a valid box_opened event', () => {
+    expect(
+      isAppEvent({
+        id: 'ev_1',
+        timestamp: '2026-05-14T12:00:00.000Z',
+        type: 'box_opened',
+        boxId: 'b1',
+        flavorId: 'f1',
+      })
+    ).toBe(true);
+  });
+
+  it('accepts a valid box_removed event', () => {
+    expect(
+      isAppEvent({
+        id: 'ev_1',
+        timestamp: '2026-05-14T12:00:00.000Z',
+        type: 'box_removed',
+        boxId: 'b1',
+        flavorId: 'f1',
+        finalQuantity: 3,
+      })
+    ).toBe(true);
+  });
+
+  it('accepts a valid shake_taken event for the random path', () => {
+    expect(
+      isAppEvent({
+        id: 'ev_1',
+        timestamp: '2026-05-14T12:00:00.000Z',
+        type: 'shake_taken',
+        boxId: 'b1',
+        flavorId: 'f1',
+        method: 'random',
+        pool: 'caffeinated',
+      })
+    ).toBe(true);
+  });
+
+  it('accepts a valid shake_taken event for the favorite path with null pool', () => {
+    expect(
+      isAppEvent({
+        id: 'ev_1',
+        timestamp: '2026-05-14T12:00:00.000Z',
+        type: 'shake_taken',
+        boxId: 'b1',
+        flavorId: 'f1',
+        method: 'favorite',
+        pool: null,
+      })
+    ).toBe(true);
+  });
+
+  it('accepts a valid shake_rejected event', () => {
+    expect(
+      isAppEvent({
+        id: 'ev_1',
+        timestamp: '2026-05-14T12:00:00.000Z',
+        type: 'shake_rejected',
+        rejectedFlavorId: 'f1',
+        method: 'random',
+        pool: 'caffeine-free',
+      })
+    ).toBe(true);
+  });
+
+  it('accepts a valid selection_cancelled event with null flavorId', () => {
+    expect(
+      isAppEvent({
+        id: 'ev_1',
+        timestamp: '2026-05-14T12:00:00.000Z',
+        type: 'selection_cancelled',
+        flavorId: null,
+        method: 'random',
+        pool: 'caffeinated',
+      })
+    ).toBe(true);
+  });
+});
+
+describe('isAppEvent — negative cases', () => {
+  it('rejects null', () => {
+    expect(isAppEvent(null)).toBe(false);
+  });
+
+  it('rejects non-object', () => {
+    expect(isAppEvent('hello')).toBe(false);
+    expect(isAppEvent(42)).toBe(false);
+  });
+
+  it('rejects missing id', () => {
+    expect(
+      isAppEvent({
+        timestamp: '2026-05-14T12:00:00.000Z',
+        type: 'box_opened',
+        boxId: 'b1',
+        flavorId: 'f1',
+      })
+    ).toBe(false);
+  });
+
+  it('rejects empty id', () => {
+    expect(
+      isAppEvent({
+        id: '',
+        timestamp: '2026-05-14T12:00:00.000Z',
+        type: 'box_opened',
+        boxId: 'b1',
+        flavorId: 'f1',
+      })
+    ).toBe(false);
+  });
+
+  it('rejects missing timestamp', () => {
+    expect(
+      isAppEvent({
+        id: 'ev_1',
+        type: 'box_opened',
+        boxId: 'b1',
+        flavorId: 'f1',
+      })
+    ).toBe(false);
+  });
+
+  it('rejects unknown type', () => {
+    expect(
+      isAppEvent({
+        id: 'ev_1',
+        timestamp: '2026-05-14T12:00:00.000Z',
+        type: 'something_else',
+        boxId: 'b1',
+      })
+    ).toBe(false);
+  });
+
+  it('rejects box_received with invalid location', () => {
+    expect(
+      isAppEvent({
+        id: 'ev_1',
+        timestamp: '2026-05-14T12:00:00.000Z',
+        type: 'box_received',
+        boxId: 'b1',
+        flavorId: 'f1',
+        quantity: 12,
+        location: { stack: -1, height: 0 },
+        isOpen: false,
+      })
+    ).toBe(false);
+  });
+
+  it('rejects box_received with negative quantity', () => {
+    expect(
+      isAppEvent({
+        id: 'ev_1',
+        timestamp: '2026-05-14T12:00:00.000Z',
+        type: 'box_received',
+        boxId: 'b1',
+        flavorId: 'f1',
+        quantity: -1,
+        location: { stack: 0, height: 0 },
+        isOpen: false,
+      })
+    ).toBe(false);
+  });
+
+  it('rejects shake_taken with invalid method', () => {
+    expect(
+      isAppEvent({
+        id: 'ev_1',
+        timestamp: '2026-05-14T12:00:00.000Z',
+        type: 'shake_taken',
+        boxId: 'b1',
+        flavorId: 'f1',
+        method: 'guessing',
+        pool: 'caffeinated',
+      })
+    ).toBe(false);
+  });
+
+  it('rejects shake_taken with invalid pool', () => {
+    expect(
+      isAppEvent({
+        id: 'ev_1',
+        timestamp: '2026-05-14T12:00:00.000Z',
+        type: 'shake_taken',
+        boxId: 'b1',
+        flavorId: 'f1',
+        method: 'random',
+        pool: 'energy-drink',
+      })
+    ).toBe(false);
+  });
+
+  it('rejects selection_cancelled with non-string non-null flavorId', () => {
+    expect(
+      isAppEvent({
+        id: 'ev_1',
+        timestamp: '2026-05-14T12:00:00.000Z',
+        type: 'selection_cancelled',
+        flavorId: 42,
+        method: 'random',
+        pool: 'caffeinated',
+      })
+    ).toBe(false);
+  });
+});

--- a/tests/unit/models.test.ts
+++ b/tests/unit/models.test.ts
@@ -283,18 +283,19 @@ describe('isBox', () => {
 describe('isAppState', () => {
   it('returns true for valid empty AppState', () => {
     const validAppState: AppState = {
-      version: 2,
+      version: 3,
       boxes: [],
       flavors: [],
       favoriteFlavorId: null,
       settings: {},
+      events: [],
     };
     expect(isAppState(validAppState)).toBe(true);
   });
 
   it('returns true for AppState with data', () => {
     const appState: AppState = {
-      version: 2,
+      version: 3,
       boxes: [
         {
           id: 'box_001',
@@ -313,30 +314,76 @@ describe('isAppState', () => {
       ],
       favoriteFlavorId: 'flavor_001',
       settings: {},
+      events: [
+        {
+          id: 'ev_1',
+          timestamp: '2026-05-14T12:00:00.000Z',
+          type: 'box_opened',
+          boxId: 'box_001',
+          flavorId: 'flavor_001',
+        },
+      ],
     };
     expect(isAppState(appState)).toBe(true);
   });
 
   it('returns true for AppState with null favoriteFlavorId', () => {
     const appState: AppState = {
-      version: 2,
+      version: 3,
       boxes: [],
       flavors: [],
       favoriteFlavorId: null,
       settings: {},
+      events: [],
     };
     expect(isAppState(appState)).toBe(true);
   });
 
   it('returns true for AppState with future version', () => {
     const appState = {
-      version: 2,
+      version: 3,
+      boxes: [],
+      flavors: [],
+      favoriteFlavorId: null,
+      settings: {},
+      events: [],
+    };
+    expect(isAppState(appState)).toBe(true);
+  });
+
+  it('returns false when events field is missing', () => {
+    const invalidAppState = {
+      version: 3,
       boxes: [],
       flavors: [],
       favoriteFlavorId: null,
       settings: {},
     };
-    expect(isAppState(appState)).toBe(true);
+    expect(isAppState(invalidAppState)).toBe(false);
+  });
+
+  it('returns false when events is not an array', () => {
+    const invalidAppState = {
+      version: 3,
+      boxes: [],
+      flavors: [],
+      favoriteFlavorId: null,
+      settings: {},
+      events: 'not an array',
+    };
+    expect(isAppState(invalidAppState)).toBe(false);
+  });
+
+  it('returns false when an event in events array is invalid', () => {
+    const invalidAppState = {
+      version: 3,
+      boxes: [],
+      flavors: [],
+      favoriteFlavorId: null,
+      settings: {},
+      events: [{ id: '', timestamp: '', type: 'box_opened' }],
+    };
+    expect(isAppState(invalidAppState)).toBe(false);
   });
 
   it('returns false for missing version', () => {
@@ -484,9 +531,9 @@ describe('createDefaultAppState', () => {
     expect(isAppState(defaultState)).toBe(true);
   });
 
-  it('has version 2', () => {
+  it('has version 3', () => {
     const defaultState = createDefaultAppState();
-    expect(defaultState.version).toBe(2);
+    expect(defaultState.version).toBe(3);
   });
 
   it('has empty boxes array', () => {
@@ -507,6 +554,11 @@ describe('createDefaultAppState', () => {
   it('has empty settings object', () => {
     const defaultState = createDefaultAppState();
     expect(defaultState.settings).toEqual({});
+  });
+
+  it('has empty events array', () => {
+    const defaultState = createDefaultAppState();
+    expect(defaultState.events).toEqual([]);
   });
 
   it('creates a new object each time', () => {

--- a/tests/unit/random-selection.test.ts
+++ b/tests/unit/random-selection.test.ts
@@ -33,11 +33,12 @@ describe('selectRandomFlavor', () => {
     boxes: Box[],
     favoriteFlavorId: string | null = null
   ): AppState => ({
-    version: 2,
+    version: 3,
     flavors,
     boxes,
     favoriteFlavorId,
     settings: {},
+    events: [],
   });
 
   const defaultPool: RandomPool = 'caffeine-free';

--- a/tests/unit/sample-data.test.ts
+++ b/tests/unit/sample-data.test.ts
@@ -16,7 +16,12 @@ describe('generateSampleData', () => {
 
   it('should have correct schema version', () => {
     const data = generateSampleData();
-    expect(data.version).toBe(2);
+    expect(data.version).toBe(3);
+  });
+
+  it('should include an empty events timeline', () => {
+    const data = generateSampleData();
+    expect(data.events).toEqual([]);
   });
 
   describe('flavors', () => {

--- a/tests/unit/storage.test.ts
+++ b/tests/unit/storage.test.ts
@@ -35,16 +35,17 @@ describe('storage', () => {
       const defaultState = createDefaultAppState();
 
       expect(state).toEqual(defaultState);
-      expect(state.version).toBe(2);
+      expect(state.version).toBe(3);
       expect(state.boxes).toEqual([]);
       expect(state.flavors).toEqual([]);
       expect(state.favoriteFlavorId).toBeNull();
       expect(state.settings).toEqual({});
+      expect(state.events).toEqual([]);
     });
 
     it('should load valid state from localStorage', () => {
       const validState: AppState = {
-        version: 2,
+        version: 3,
         boxes: [
           {
             id: 'box1',
@@ -63,6 +64,7 @@ describe('storage', () => {
         ],
         favoriteFlavorId: 'flavor1',
         settings: {},
+        events: [],
       };
 
       localStorage.setItem(STORAGE_KEY, JSON.stringify(validState));
@@ -227,7 +229,7 @@ describe('storage', () => {
   describe('saveState', () => {
     it('should save valid state to localStorage', () => {
       const validState: AppState = {
-        version: 2,
+        version: 3,
         boxes: [
           {
             id: 'box1',
@@ -246,6 +248,7 @@ describe('storage', () => {
         ],
         favoriteFlavorId: 'flavor1',
         settings: {},
+        events: [],
       };
 
       saveState(validState);
@@ -371,7 +374,7 @@ describe('storage', () => {
     });
   });
 
-  describe('v1 to v2 migration', () => {
+  describe('schema migration', () => {
     it('should migrate v1 state with excludeFromRandom: false to randomPool caffeine-free', () => {
       const v1State = {
         version: 1,
@@ -390,7 +393,7 @@ describe('storage', () => {
       localStorage.setItem(STORAGE_KEY, JSON.stringify(v1State));
 
       const loaded = loadState();
-      expect(loaded.version).toBe(2);
+      expect(loaded.version).toBe(3);
       expect(loaded.flavors[0].randomPool).toBe('caffeine-free');
       expect((loaded.flavors[0] as Record<string, unknown>).excludeFromRandom).toBeUndefined();
     });
@@ -413,7 +416,7 @@ describe('storage', () => {
       localStorage.setItem(STORAGE_KEY, JSON.stringify(v1State));
 
       const loaded = loadState();
-      expect(loaded.version).toBe(2);
+      expect(loaded.version).toBe(3);
       expect(loaded.flavors[0].randomPool).toBeNull();
     });
 
@@ -433,26 +436,76 @@ describe('storage', () => {
       localStorage.setItem(STORAGE_KEY, JSON.stringify(v1State));
 
       const loaded = loadState();
-      expect(loaded.version).toBe(2);
+      expect(loaded.version).toBe(3);
       expect(loaded.flavors[0].randomPool).toBe('caffeine-free');
       expect(loaded.flavors[1].randomPool).toBe('caffeine-free');
       expect(loaded.flavors[2].randomPool).toBeNull();
     });
 
-    it('should not migrate v2 state', () => {
-      const v2State: AppState = {
-        version: 2,
+    it('should chain v1 through to v3, adding an empty events array', () => {
+      const v1State = {
+        version: 1,
         boxes: [],
-        flavors: [{ id: 'f1', name: 'Chocolate', randomPool: 'caffeinated' }],
+        flavors: [{ id: 'f1', name: 'Chocolate', excludeFromRandom: false }],
         favoriteFlavorId: null,
+        settings: {},
+      };
+
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(v1State));
+
+      const loaded = loadState();
+      expect(loaded.version).toBe(3);
+      expect(loaded.events).toEqual([]);
+    });
+
+    it('should migrate v2 state to v3 with an empty events array', () => {
+      const v2State = {
+        version: 2,
+        boxes: [
+          {
+            id: 'box1',
+            flavorId: 'f1',
+            quantity: 12,
+            location: { stack: 0, height: 0 },
+            isOpen: false,
+          },
+        ],
+        flavors: [{ id: 'f1', name: 'Chocolate', randomPool: 'caffeinated' }],
+        favoriteFlavorId: 'f1',
         settings: {},
       };
 
       localStorage.setItem(STORAGE_KEY, JSON.stringify(v2State));
 
       const loaded = loadState();
-      expect(loaded.version).toBe(2);
+      expect(loaded.version).toBe(3);
+      expect(loaded.events).toEqual([]);
       expect(loaded.flavors[0].randomPool).toBe('caffeinated');
+      expect(loaded.boxes).toHaveLength(1);
+    });
+
+    it('should not modify v3 state during migration', () => {
+      const v3State: AppState = {
+        version: 3,
+        boxes: [],
+        flavors: [{ id: 'f1', name: 'Chocolate', randomPool: 'caffeinated' }],
+        favoriteFlavorId: null,
+        settings: {},
+        events: [
+          {
+            id: 'ev_existing',
+            timestamp: '2026-05-01T12:00:00.000Z',
+            type: 'box_opened',
+            boxId: 'box1',
+            flavorId: 'f1',
+          },
+        ],
+      };
+
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(v3State));
+
+      const loaded = loadState();
+      expect(loaded).toEqual(v3State);
     });
 
     it('should preserve boxes and other state during migration', () => {
@@ -484,7 +537,7 @@ describe('storage', () => {
   describe('integration scenarios', () => {
     it('should persist state across save and load', () => {
       const originalState: AppState = {
-        version: 2,
+        version: 3,
         boxes: [
           {
             id: 'box1',
@@ -515,6 +568,7 @@ describe('storage', () => {
         ],
         favoriteFlavorId: 'flavor1',
         settings: {},
+        events: [],
       };
 
       saveState(originalState);

--- a/tests/unit/stores.test.ts
+++ b/tests/unit/stores.test.ts
@@ -19,6 +19,9 @@ import {
   addFlavor,
   updateFlavor,
   setFavoriteFlavor,
+  recordShakeTaken,
+  recordShakeRejected,
+  recordSelectionCancelled,
 } from '../../src/lib/stores';
 import type { AppState, Box, Flavor } from '../../src/types/models';
 
@@ -76,7 +79,8 @@ describe('stores', () => {
       expect(state.flavors).toEqual([]);
       expect(state.favoriteFlavorId).toBeNull();
       expect(state.settings).toEqual({});
-      expect(state.version).toBe(2);
+      expect(state.events).toEqual([]);
+      expect(state.version).toBe(3);
     });
 
     it('should initialize with data from localStorage if available', () => {
@@ -126,11 +130,12 @@ describe('stores', () => {
   describe('replaceAppState', () => {
     it('replaces the entire state when given a valid AppState', () => {
       const incoming: AppState = {
-        version: 2,
+        version: 3,
         boxes: [createTestBox({ id: 'replaced_box' })],
         flavors: [createTestFlavor({ id: 'replaced_flavor' })],
         favoriteFlavorId: 'replaced_flavor',
         settings: {},
+        events: [],
       };
 
       replaceAppState(incoming);
@@ -143,7 +148,7 @@ describe('stores', () => {
 
     it('throws and does not mutate the store when given an invalid state', () => {
       const before = getCurrentState();
-      const bogus = { version: 2, boxes: 'not-an-array' } as unknown as AppState;
+      const bogus = { version: 3, boxes: 'not-an-array' } as unknown as AppState;
 
       expect(() => replaceAppState(bogus)).toThrow(/schema validation failed/);
       expect(getCurrentState()).toEqual(before);
@@ -906,6 +911,190 @@ describe('stores', () => {
       expect(parsed.flavors).toHaveLength(3);
       expect(parsed.boxes).toHaveLength(4);
       expect(parsed.favoriteFlavorId).toBe('choc');
+    });
+  });
+
+  describe('Event timeline emission', () => {
+    it('emits a box_received event when a box is added', () => {
+      const box = createTestBox({ id: 'box_evt_1', flavorId: 'flavor_evt' });
+      addBox(box);
+
+      const events = getCurrentState().events;
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({
+        type: 'box_received',
+        boxId: 'box_evt_1',
+        flavorId: 'flavor_evt',
+        quantity: box.quantity,
+        location: box.location,
+        isOpen: box.isOpen,
+      });
+      expect(events[0].id).toMatch(/^ev_/);
+      expect(events[0].timestamp).toBeTruthy();
+    });
+
+    it('emits a box_removed event including the final quantity', () => {
+      const box = createTestBox({ id: 'box_evt_2', flavorId: 'flavor_evt', quantity: 5 });
+      addBox(box);
+      updateBoxQuantity('box_evt_2', 2);
+      removeBox('box_evt_2');
+
+      const events = getCurrentState().events;
+      const removed = events.find((e) => e.type === 'box_removed');
+      expect(removed).toBeDefined();
+      expect(removed).toMatchObject({
+        type: 'box_removed',
+        boxId: 'box_evt_2',
+        flavorId: 'flavor_evt',
+        finalQuantity: 2,
+      });
+    });
+
+    it('emits box_opened only on the false→true transition', () => {
+      const box = createTestBox({ id: 'box_evt_3', isOpen: false });
+      addBox(box);
+      const eventsBefore = getCurrentState().events.length;
+
+      updateBoxIsOpen('box_evt_3', true);
+      const eventsAfterOpen = getCurrentState().events;
+      expect(eventsAfterOpen.length).toBe(eventsBefore + 1);
+      expect(eventsAfterOpen.at(-1)).toMatchObject({
+        type: 'box_opened',
+        boxId: 'box_evt_3',
+      });
+
+      // Re-opening an already-open box should not emit another event
+      updateBoxIsOpen('box_evt_3', true);
+      expect(getCurrentState().events.length).toBe(eventsBefore + 1);
+
+      // Closing the box should NOT emit any event
+      updateBoxIsOpen('box_evt_3', false);
+      expect(getCurrentState().events.length).toBe(eventsBefore + 1);
+
+      // Opening again should emit
+      updateBoxIsOpen('box_evt_3', true);
+      expect(getCurrentState().events.length).toBe(eventsBefore + 2);
+    });
+
+    it('does not emit timeline events for manual updateBoxQuantity calls', () => {
+      const box = createTestBox({ id: 'box_evt_4', quantity: 12 });
+      addBox(box);
+      const eventsBefore = getCurrentState().events.length;
+
+      updateBoxQuantity('box_evt_4', 11);
+      updateBoxQuantity('box_evt_4', 10);
+
+      expect(getCurrentState().events.length).toBe(eventsBefore);
+    });
+  });
+
+  describe('recordShakeTaken', () => {
+    it('decrements quantity and appends a shake_taken event', () => {
+      addBox(createTestBox({ id: 'box_s1', flavorId: 'flavor_s1', quantity: 5 }));
+      const eventsBefore = getCurrentState().events.length;
+
+      recordShakeTaken({
+        boxId: 'box_s1',
+        flavorId: 'flavor_s1',
+        method: 'random',
+        pool: 'caffeinated',
+      });
+
+      const state = getCurrentState();
+      expect(state.boxes.find((b) => b.id === 'box_s1')?.quantity).toBe(4);
+      expect(state.events.length).toBe(eventsBefore + 1);
+      expect(state.events.at(-1)).toMatchObject({
+        type: 'shake_taken',
+        boxId: 'box_s1',
+        flavorId: 'flavor_s1',
+        method: 'random',
+        pool: 'caffeinated',
+      });
+    });
+
+    it('captures favorite-method shakes with a null pool', () => {
+      addBox(createTestBox({ id: 'box_s2', flavorId: 'flavor_s2', quantity: 3 }));
+      recordShakeTaken({
+        boxId: 'box_s2',
+        flavorId: 'flavor_s2',
+        method: 'favorite',
+        pool: null,
+      });
+      const last = getCurrentState().events.at(-1);
+      expect(last).toMatchObject({ type: 'shake_taken', method: 'favorite', pool: null });
+    });
+
+    it('throws when the box does not exist', () => {
+      expect(() =>
+        recordShakeTaken({
+          boxId: 'nonexistent',
+          flavorId: 'flavor_x',
+          method: 'random',
+          pool: 'caffeinated',
+        })
+      ).toThrow(/not found/);
+    });
+
+    it('throws when the box quantity is already zero', () => {
+      addBox(createTestBox({ id: 'box_s3', flavorId: 'flavor_s3', quantity: 0 }));
+      expect(() =>
+        recordShakeTaken({
+          boxId: 'box_s3',
+          flavorId: 'flavor_s3',
+          method: 'random',
+          pool: 'caffeinated',
+        })
+      ).toThrow(/empty/);
+    });
+  });
+
+  describe('recordShakeRejected', () => {
+    it('appends a shake_rejected event without touching boxes', () => {
+      addBox(createTestBox({ id: 'box_r1', flavorId: 'flavor_r1', quantity: 5 }));
+      const beforeBoxes = getCurrentState().boxes;
+
+      recordShakeRejected({
+        rejectedFlavorId: 'flavor_r1',
+        method: 'random',
+        pool: 'caffeine-free',
+      });
+
+      const state = getCurrentState();
+      expect(state.boxes).toEqual(beforeBoxes);
+      expect(state.events.at(-1)).toMatchObject({
+        type: 'shake_rejected',
+        rejectedFlavorId: 'flavor_r1',
+        method: 'random',
+        pool: 'caffeine-free',
+      });
+    });
+  });
+
+  describe('recordSelectionCancelled', () => {
+    it('appends a selection_cancelled event with a known flavor', () => {
+      recordSelectionCancelled({
+        flavorId: 'flavor_c1',
+        method: 'manual',
+        pool: null,
+      });
+      expect(getCurrentState().events.at(-1)).toMatchObject({
+        type: 'selection_cancelled',
+        flavorId: 'flavor_c1',
+        method: 'manual',
+        pool: null,
+      });
+    });
+
+    it('accepts a null flavorId for cancellations without a chosen flavor', () => {
+      recordSelectionCancelled({
+        flavorId: null,
+        method: 'random',
+        pool: 'caffeinated',
+      });
+      expect(getCurrentState().events.at(-1)).toMatchObject({
+        type: 'selection_cancelled',
+        flavorId: null,
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary
- **PR 1 of a 3-PR plan** toward a multi-device data backend (PR 2: Supabase + magic-link auth + sync; PR 3: realtime + offline queue + conflict resolution).
- Adds a local append-only event timeline inside `AppState`. Schema bumps to **v3** with a chained v1→v2→v3 migration.
- Captures six event types — `box_received`, `box_opened`, `box_removed`, `shake_taken`, `shake_rejected`, `selection_cancelled` — covering the dates you asked about (received/opened) and every selection moment including "no transaction" rejections and cancellations.
- Events flow into the existing backup JSON export with no changes to the backup pipeline.
- No new UI in this PR. Verify via DevTools (\`localStorage['BROTEINBUDDY_APP_STATE'].events\`) or a backup download.

## What's deliberately out of scope
- Server / auth / network — PR 2.
- Reporting UI ("when do I take shakes?") — instrumentation only.
- Backfilling synthetic \`box_received\` events for pre-existing boxes (their real receive dates are unknown).
- \`selection_initiated\`, \`box_quantity_adjusted\`, \`box_location_changed\`, \`box_closed\` — additive later without a schema bump.

See \`docs/adr/011-event-timeline.md\` for the full rationale.

## Test plan
- [x] \`npm test\` — 529 unit tests pass (30+ new tests for events, store emission, schema migration, backup round-trip)
- [x] \`npm run test:e2e\` — 346 e2e tests pass, including a new assertion that confirming a random pick writes a \`shake_taken\` event with the correct method/pool
- [x] \`npm run check\` — svelte-check clean (only pre-existing warnings)
- [x] \`npm run lint\` — clean
- [x] \`npm run format:check\` — clean
- [x] \`npm run build\` — production bundle builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)