### PR TITLE
Add Supabase sync + magic-link auth (PR 2 of 3)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# BroteinBuddy environment variables. Copy this file to `.env.local` (which
+# is git-ignored) and fill in real values for local development.
+#
+# Production values live in the Vercel project settings under
+# Project → Settings → Environment Variables.
+#
+# All VITE_* vars are baked into the client bundle. The Supabase anon key
+# is safe to expose because row-level security on the database enforces
+# per-user access. NEVER paste the service_role key here or anywhere
+# client-side.
+
+VITE_SUPABASE_URL=https://your-project-ref.supabase.co
+VITE_SUPABASE_ANON_KEY=your-anon-key-here

--- a/docs/adr/012-supabase-sync.md
+++ b/docs/adr/012-supabase-sync.md
@@ -1,0 +1,227 @@
+# ADR-012: Supabase-Backed Sync with Magic-Link Auth
+
+**Status:** Accepted
+
+**Date:** 2026-05-14
+
+**Deciders:** Nik Blanchet
+
+---
+
+## Context
+
+### Background
+
+PR 1 (ADR-011) introduced an append-only event timeline inside `AppState`,
+laying the groundwork for multi-device sync. PR 2 (this ADR) makes the
+data actually multi-device by introducing a server, an auth system, and a
+push/pull sync protocol.
+
+The 3-PR plan from the original design:
+
+1. Local event timeline (ADR-011, shipped).
+2. **Server + auth + push/pull sync** (this ADR).
+3. Realtime subscribe + offline event queue + conflict resolution.
+
+### Problem statement
+
+The same inventory data needs to be available on multiple devices (phone +
+laptop, primarily). The app must:
+
+- Continue to work offline / signed-out exactly as before.
+- Offer optional sign-in. Sign-in is the user's signal that they want
+  multi-device sync; the local-only path stays intact for users who don't.
+- Surface a clear chooser when local and server data collide on a new
+  sign-in — neither side gets silently overwritten.
+- Push fast enough to feel like "save as you go" but without hammering the
+  server on every keystroke.
+- Be trivial to undo: a sign-out reverts the device to local-only without
+  touching the server.
+
+Out of scope (PR 3): realtime, offline queue, field-level merge.
+
+## Decision
+
+We will use **Supabase** as the backend — Postgres + GoTrue auth + RLS in a
+single managed service. Auth is **magic link via email** (passwordless).
+Sync is **debounced push, pull on app start, conflict modal on first
+sign-in with diverging state**.
+
+### Implementation details
+
+- **Schema (Postgres):** Two tables, both RLS-protected.
+  - `app_states` — one row per user. Holds boxes, flavors, favorite,
+    settings, version. Overwritten on every push.
+  - `events` — append-only timeline. Primary key is the
+    client-generated `ev_<uuid>`, so re-pushing an event with the same id is
+    a no-op (ON CONFLICT DO NOTHING).
+
+  The split mirrors the client layout (`AppState` snapshot fields vs the
+  `events[]` array) and lets PR 3 subscribe to the `events` table in
+  realtime without a schema change. SQL lives in
+  `supabase/migrations/20260514000000_initial_app_state_and_events.sql`.
+
+- **Auth:** magic link via `supabase.auth.signInWithOtp`. PKCE flow.
+  Tokens persist in localStorage so the user stays signed in across reloads.
+  The redirect URL is `window.location.origin` — supabase-js parses the
+  callback automatically on app load, so we don't need a dedicated
+  `/auth/callback` route.
+
+- **Module layout:**
+  - `src/lib/supabase.ts` — client singleton. Reads
+    `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` from Vite env vars.
+    Exports `null` when vars are missing so the rest of the app gracefully
+    degrades to local-only.
+  - `src/lib/auth.ts` — `sendMagicLink`, `signOut`, and a `session`
+    readable store hooked to `onAuthStateChange`.
+  - `src/lib/sync.ts` — `pushFullState`, `pullFullState`,
+    `peekRemoteState`, `clearRemoteState`. Pure functions, no stores.
+  - `src/lib/sync-coordinator.ts` — wires everything together. Subscribes
+    to auth events and to the `appState` store. Owns debouncing, conflict
+    detection, and the sync status / pending-conflict stores.
+
+- **Push semantics:**
+  - Debounced by 2.5 s. Coalesces rapid mutations into one round-trip.
+  - On every push: upsert the snapshot row, then upsert events (idempotent
+    by id). Snapshot is last-write-wins, events are union-merged.
+  - Tunable via `setPushDelay(ms)` for tests.
+
+- **Pull semantics:**
+  - `INITIAL_SESSION` (page load with cached session): silent pull,
+    replace local. Trusts the cached session.
+  - `SIGNED_IN` (new sign-in): peek server first.
+    - Server empty: push local to seed.
+    - Local empty: pull server.
+    - Both populated: surface a pending conflict for the UI.
+
+- **Conflict resolution UI (`ConflictResolutionModal.svelte`):** Renders
+  whenever `pendingConflict` is non-null. Three actions: _Keep this
+  device_ (wipes server, then pushes local), _Keep server_ (pulls,
+  replaces local), _Cancel sign-in_ (signs out without touching data).
+
+- **Sync UI (`SyncAccountModal.svelte`):** Lives behind a "Sync" button in
+  the Inventory page header, next to the existing "Backup" button. Two
+  states: signed-out (email + send-link), signed-in (email, status, sign
+  out). Renders a friendly notice when env vars are missing rather than a
+  crash.
+
+- **Suppress-outbound flag:** When the coordinator replaces local state
+  with server data (pull or `keep-server` resolution), it sets a flag so
+  the resulting `appState.subscribe` fire-back doesn't trigger an immediate
+  re-push. Without this, a successful pull would push the same data right
+  back.
+
+- **Idempotent push design:** Snapshot upserts by `user_id` (the primary
+  key); events upsert by `id` with `ignoreDuplicates: true`. Re-pushing
+  the same payload is safe and cheap (no row writes for unchanged events).
+
+## Consequences
+
+### Positive
+
+- Single managed service for Postgres + auth keeps the moving parts low.
+  Vercel handles the static client; Supabase handles everything else.
+- Magic link removes a whole class of UX work (password reset, password
+  strength, lockout) for a personal app where the cost of a slightly
+  slower sign-in is irrelevant.
+- The two-table schema lines up with PR 3 in a natural way: events become
+  a Realtime subscription source.
+- The anon key shipped in the client bundle is safe because RLS enforces
+  per-user access. Service-role key is never used client-side.
+- The "not configured" graceful degradation means contributors who clone
+  the repo without filling in env vars get a working local app — they
+  just can't sync.
+
+### Negative
+
+- Adds a runtime dependency on Supabase availability. If Supabase is down
+  for signed-in users, the indicator goes to "error" but the local app
+  keeps working. Acceptable for personal use; would need an offline
+  queue for higher reliability (PR 3).
+- Every snapshot push re-serializes the entire `app_states` row. With a
+  small inventory this is fine; the row size is unbounded in theory.
+- The conflict modal is blocking and synchronous: once it appears, no
+  pushes happen until the user resolves. A power user with rapid
+  sign-in/sign-out cycles could find this jarring; not expected in normal
+  use.
+
+### Neutral
+
+- The chosen "snapshot last-write-wins, events union-merge" semantics
+  mean a user who edits inventory on Device A while Device B is offline
+  will lose Device A's edits if Device B pushes a stale snapshot after
+  reconnecting. PR 3 will fix this via realtime + offline queue.
+- Pushing on every mutation rather than batching across feature
+  transactions means even ephemeral state (e.g. the user is mid-add) goes
+  to the server. That's fine: the snapshot is always the authoritative
+  current state, and there's no concept of "draft" inventory.
+
+## Alternatives Considered
+
+### Alternative 1: Vercel Postgres + Auth.js (NextAuth)
+
+Stay entirely on Vercel: serverless functions in `/api`, Postgres via
+Vercel Postgres or Neon, Auth.js for the magic-link flow.
+
+- **Pros:** Single cloud bill, single dashboard, no second provider.
+- **Cons:** Significantly more glue code. Auth.js + serverless + Postgres
+  setup is several days of plumbing for what Supabase ships out of the
+  box. RLS-equivalent isolation has to be enforced in API handlers,
+  which is more code to audit.
+
+Rejected. Supabase's all-in-one model is a better fit for a personal
+project.
+
+### Alternative 2: Firebase / Firestore
+
+Google's managed NoSQL with built-in auth (Apple/Google sign-in).
+
+- **Pros:** Excellent offline sync story; first-class Apple sign-in.
+- **Cons:** Document model doesn't match the project's normalised schema
+  without restructuring. Vendor lock-in is heavier; SQL escape hatch is
+  not available.
+
+Rejected. Not worth the schema reshaping.
+
+### Alternative 3: Single JSONB row schema
+
+One row per user, one JSONB column holding the entire `AppState`.
+
+- **Pros:** Dead-simple push/pull (one upsert, one select).
+- **Cons:** PR 3 wants realtime subscriptions on events, which works much
+  better with a real events table. Migrating later is more work than
+  splitting now.
+
+Rejected.
+
+### Alternative 4: Required sign-in on first launch
+
+Lock the app behind sign-in to simplify the sync model.
+
+- **Pros:** No "is this device synced?" ambiguity.
+- **Cons:** Changes the everyday UX of an app whose daily-use mode has
+  always been "open and tap." Loses the local-only escape hatch entirely.
+
+Rejected. Sign-in stays optional, in Settings.
+
+### Alternative 5: Event-by-event sync (skip the snapshot push)
+
+Stream events to the server one by one; derive the snapshot server-side
+by replaying.
+
+- **Pros:** Elegant; the event log is the only source of truth.
+- **Cons:** Read performance hits O(events) for every pull. With 3-5
+  events/day × years, the log grows large enough to want compaction.
+  Pushing snapshots is dumber but faster and keeps PR 2 scoped.
+
+Rejected for PR 2. PR 3 may revisit if compaction matters.
+
+## References
+
+- ADR-002: Data Model Design
+- ADR-003: LocalStorage Strategy
+- ADR-010: Backup/Restore Design
+- ADR-011: Local Event Timeline (PR 1)
+- Supabase Auth docs: <https://supabase.com/docs/guides/auth>
+- Supabase Row Level Security: <https://supabase.com/docs/guides/auth/row-level-security>
+- Teaching doc: `docs/teaching/1.7-supabase-magic-link-sync.md`

--- a/docs/teaching/1.7-supabase-magic-link-sync.md
+++ b/docs/teaching/1.7-supabase-magic-link-sync.md
@@ -1,0 +1,704 @@
+# Supabase, Magic Links, and a Push/Pull Sync Coordinator
+
+**Deliverable:** 1.7 — Supabase-backed sync (PR #95, branch `feature/supabase-sync`)
+**Author:** Claude Code
+**Date:** 2026-05-14
+**Skill Level:** Intermediate / Architectural
+
+---
+
+## Table of Contents
+
+1. [What Changed and Why It Matters](#what-changed-and-why-it-matters)
+2. [Why Supabase, and the Cost of That Choice](#why-supabase-and-the-cost-of-that-choice)
+3. [Row-Level Security: Why the Anon Key Is Safe in the Bundle](#row-level-security-why-the-anon-key-is-safe-in-the-bundle)
+4. [Magic Link, PKCE, and Why No Passwords](#magic-link-pkce-and-why-no-passwords)
+5. [Two Tables, Not One JSONB Blob](#two-tables-not-one-jsonb-blob)
+6. [Idempotent Push by Way of Client-Generated IDs](#idempotent-push-by-way-of-client-generated-ids)
+7. [The Sync Coordinator as a State Machine](#the-sync-coordinator-as-a-state-machine)
+8. [The Suppress-Outbound-Push Flag](#the-suppress-outbound-push-flag)
+9. [Debounced Push: Coalescing Without Losing (Much)](#debounced-push-coalescing-without-losing-much)
+10. [Graceful Degradation When Env Vars Are Missing](#graceful-degradation-when-env-vars-are-missing)
+11. [Conflict Resolution: Three Explicit Branches](#conflict-resolution-three-explicit-branches)
+12. [What We Deliberately Did NOT Do](#what-we-deliberately-did-not-do)
+13. [Further Reading](#further-reading)
+
+---
+
+## What Changed and Why It Matters
+
+Up to and including PR #94 (the local event timeline), BroteinBuddy was
+strictly local. State lived in LocalStorage; backup/restore moved a JSON
+file through the user's file system; "multi-device" was AirDrop or iCloud,
+manually, by the user.
+
+This PR is the second of three toward real multi-device data:
+
+- A **Supabase project** (Postgres + Auth + Row-Level Security) with one
+  SQL migration creating two tables: `app_states` (snapshot) and `events`
+  (timeline).
+- A **client singleton** (`src/lib/supabase.ts`) that reads two Vite env
+  vars and returns either a configured client or `null`.
+- A **magic-link auth flow** (`src/lib/auth.ts`) wrapping
+  `supabase.auth.signInWithOtp`, plus a `session` readable store.
+- A **push/pull module** (`src/lib/sync.ts`) — pure functions translating
+  between `AppState` and the two server tables.
+- A **sync coordinator** (`src/lib/sync-coordinator.ts`) that wires auth
+  events to push/pull, debounces outbound pushes, and surfaces a pending
+  conflict when both sides have data at sign-in.
+- Two **UI components**: `SyncAccountModal.svelte` (behind a "Sync"
+  button in the Inventory header) and `ConflictResolutionModal.svelte`.
+- Graceful degradation: clones without `.env.local` get a fully
+  functional local-only app.
+
+PR 3 is the harder one: realtime subscribe, an offline queue, and
+field-level merging so two devices editing the same favorite don't
+trample each other. This PR sets up the schema, the auth, and the
+coordination scaffolding so PR 3 adds behaviour, not infrastructure.
+
+ADR-012 is the "what was decided." This document is the elaboration of
+"why each piece looks the way it does."
+
+## Why Supabase, and the Cost of That Choice
+
+Sync needs three things: a database, an identity system, and a way to
+authorize per-user access. Pick those independently and you have a lot of
+glue to write. Pick all-in-one and the trade is plumbing versus lock-in.
+
+The candidates we weighed (ADR-012 has the full matrix):
+
+- **Vercel Postgres + Auth.js.** Serverless functions in `/api`,
+  hand-rolled magic-link via Auth.js, per-user isolation enforced in each
+  API handler. Dealbreaker: isolation lives in your application code
+  instead of the database. Any future endpoint that forgets
+  `where user_id = $1` is a data-leak bug, and you'd be auditing those
+  clauses forever.
+- **Firebase / Firestore.** Great offline story, first-class Apple
+  sign-in. Dealbreaker: document model doesn't match our normalised
+  `boxes[] + flavors[] + events[]` shape, and there's no SQL escape hatch.
+- **Supabase.** Postgres + GoTrue Auth + RLS in one managed service.
+  Per-user isolation enforced by the database. Real Postgres at the
+  bottom of the stack.
+
+We picked Supabase. The decisive points: RLS (next section) and the fact
+that Postgres stays portable underneath. If Supabase ever becomes a
+problem, "`pg_dump` and move to a different Postgres host" is realistic.
+With Firebase the equivalent would be a full data-shape rewrite.
+
+The lock-in we accepted is bounded. The client library is a thin wrapper;
+RLS is standard Postgres; hosted Postgres is trivially portable. GoTrue
+is the only piece that would be painful to replace. For a personal
+project, fine.
+
+## Row-Level Security: Why the Anon Key Is Safe in the Bundle
+
+This trips people up the first time they see it. From
+`src/lib/supabase.ts:15-16`:
+
+```ts
+const url = import.meta.env.VITE_SUPABASE_URL as string | undefined;
+const anonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined;
+```
+
+`anonKey` ends up baked into the JavaScript bundle. Every visitor sees
+it. If you're used to API keys being secrets, that should make your hair
+stand up. It's fine. Here's why.
+
+The anon key isn't a secret. It's a **public identifier** saying "I am a
+client of this Supabase project." It grants exactly one capability: act
+as the `anon` role. The `anon` role, by itself, has no permission to
+read or write any user data — _provided you've enabled Row-Level
+Security and written policies_.
+
+Our migration (`supabase/migrations/20260514000000_initial_app_state_and_events.sql:73-91`):
+
+```sql
+alter table public.app_states enable row level security;
+alter table public.events     enable row level security;
+
+create policy "app_states owner select"
+  on public.app_states for select
+  using (auth.uid() = user_id);
+
+create policy "app_states owner insert"
+  on public.app_states for insert
+  with check (auth.uid() = user_id);
+-- ... etc for update and delete
+```
+
+`auth.uid()` is a Supabase-provided Postgres function. When a request
+carries a JWT (the access token issued at sign-in), it returns the user
+ID encoded in that JWT. Bare anon key only? It returns `NULL`. The
+policy `auth.uid() = user_id` becomes `NULL = user_id`, which Postgres
+treats as "policy did not match." No rows returned. No rows insertable.
+
+What a malicious holder of the anon key cannot do: read someone else's
+data (the select policy rejects requests with no `auth.uid()`); insert
+a row impersonating another user (the insert policy's `with check`
+forces JWT user == row `user_id`). What they _can_ do: sign up
+arbitrary accounts for emails they control, but RLS confines them to
+their own rows.
+
+The thing that _is_ a real secret — the **service role key** — never
+leaves the server. We don't use it at all in this PR.
+
+The shape to keep in your head: the anon key authenticates the
+_project_, not the _user_. RLS authenticates the user. Combined: anyone
+can reach our database, but they can't see or write anything that isn't
+theirs.
+
+> **General principle:** When you have public API access tokens, put the
+> authorization checks _in the database_, not in application code. Every
+> hand-written `where user_id = $1` is a place a future bug can omit the
+> clause. RLS makes the omission impossible.
+
+## Magic Link, PKCE, and Why No Passwords
+
+Sign-in is two steps: type email, tap "Send"; open email, tap link. No
+password to make up, forget, reset, or measure the strength of. From
+`src/lib/auth.ts:82-95`:
+
+```ts
+const { error } = await supabase.auth.signInWithOtp({
+  email: trimmed,
+  options: {
+    emailRedirectTo: window.location.origin,
+    shouldCreateUser: true,
+  },
+});
+```
+
+A few interesting bits.
+
+**OTP under the hood.** Supabase calls this `signInWithOtp` — "One-Time
+Password" — even though no numeric code is involved on the client. The
+"OTP" is the unguessable token embedded in the magic-link URL. Same
+primitive as a 6-digit code, different transport. Saves the user from
+typing.
+
+**PKCE flow.** The client is configured for PKCE
+(`src/lib/supabase.ts:38`):
+
+```ts
+flowType: 'pkce',
+```
+
+PKCE (Proof Key for Code Exchange — pronounced "pixie") is the modern
+flow for public clients. Short version: client generates a random
+`code_verifier`, sends `sha256(code_verifier)` with the initial request,
+and on callback exchanges the original verifier for tokens. An attacker
+who intercepts the URL-bound auth code can't use it without the verifier,
+which never leaves the client. For magic-link this is mostly
+belt-and-suspenders — the link is already a single-use token — but the
+cost is zero and the property is worth having.
+
+**Auto URL exchange.** `detectSessionInUrl: true` (`src/lib/supabase.ts:35`).
+When the user clicks the magic link, they land back at
+`window.location.origin` with auth bits in the URL. supabase-js parses
+them on app load, calls the token-exchange endpoint, sets the session,
+and cleans the URL. We did not write a single line of callback handling.
+No `/auth/callback` route.
+
+**Session refresh.** `autoRefreshToken: true`, `persistSession: true`.
+Access tokens expire after ~1 hour. supabase-js stores access and
+refresh tokens in LocalStorage and swaps them transparently. The user
+stays signed in indefinitely as long as they open the app within the
+refresh-token lifetime. `onAuthStateChange` fires `TOKEN_REFRESHED`;
+the coordinator ignores it (`src/lib/sync-coordinator.ts:129`).
+
+**Why no email + password?** Password reset is a non-trivial UX flow.
+Password strength is a rabbit hole. "Forgot password?" is the most common
+support request in any password-based app. Magic link eliminates the
+entire category. The cost — every sign-in requires email access — is
+acceptable for a personal app.
+
+## Two Tables, Not One JSONB Blob
+
+The server stores BroteinBuddy state in two tables (full SQL in
+`supabase/migrations/20260514000000_initial_app_state_and_events.sql`).
+`app_states` is one row per user with JSONB columns for each top-level
+`AppState` field (boxes, flavors, favorite, settings, version). `events`
+is one row per `AppEvent`, with the client-generated `id text primary
+key`, `user_id`, `type`, `payload jsonb`, and `event_timestamp`.
+
+The split mirrors PR 1's client layout (see `1.6-event-timeline-design.md`
+for why snapshot and events co-locate _on the client_). On the server,
+the split is not free — we could have stored everything as one JSONB row
+of `{ snapshot, events }`. Three reasons we didn't.
+
+**Realtime subscribe is row-level.** Supabase Realtime streams Postgres
+logical-replication events. The subscription is table-and-row-shaped:
+"tell me when any row in `events` where `user_id = me` changes." With a
+single JSONB blob, every snapshot push would fire one event and every
+subscriber would diff the blob. With a split events table, PR 3
+subscribes specifically to `events` rows and gets a clean "here is the
+new event" stream — no schema change required.
+
+**Idempotent event pushes.** The events table's primary key is the
+client-generated `id`, giving us `ON CONFLICT DO NOTHING` for free.
+JSONB-array dedupe would need server-side array work.
+
+**Append-only enforcement at the database level.** No update or delete
+policy on `events` (`...:97-103`):
+
+```sql
+create policy "events owner insert"
+  on public.events for insert
+  with check (auth.uid() = user_id);
+
+-- No update/delete policy on events: the timeline is append-only on the
+-- server. Clients that want to remove rows must do it through a future
+-- admin path (PR 3 may revisit if compaction is needed).
+```
+
+A signed-in user can insert and select their own events. They cannot
+update or delete them. "The timeline is immutable once written" is a
+database-enforced property, not an application convention. JSONB
+couldn't enforce that.
+
+Cost: two queries on pull. Both are sub-millisecond at our scale —
+`events_user_id_timestamp_idx` covers the event read, and the snapshot
+is a single primary-key lookup.
+
+What we are _not_ doing: normalising inside `app_states`. The `boxes`
+and `flavors` arrays are still JSONB columns. That would be the next
+level of decomposition, and PR 3 doesn't want per-box realtime.
+
+> **General principle:** Split tables along the axis you want to
+> subscribe / authorize / index at. The database shape should mirror the
+> queries you intend to run, not just the in-memory shape.
+
+## Idempotent Push by Way of Client-Generated IDs
+
+PR 1 had a small foresight in `lib/events.ts:14-46`: every event ID is
+`ev_<uuid>` via `crypto.randomUUID()`. That detail pays for itself
+dramatically here.
+
+The event push (`src/lib/sync.ts:217-229`):
+
+```ts
+if (state.events.length === 0) return;
+
+const rows = state.events.map((event) => splitEventForRow(event, userId));
+
+// `ignoreDuplicates: true` translates to ON CONFLICT DO NOTHING — re-pushing
+// an event with the same id leaves the existing row untouched.
+const { error: evErr } = await client
+  .from('events')
+  .upsert(rows, { onConflict: 'id', ignoreDuplicates: true });
+```
+
+If the event already exists, skip; otherwise insert. Three properties
+fall out: **re-pushing the same events is a no-op** (the retry case
+after a network flake just works); **the client doesn't track per-event
+acknowledgments** (it can say "here is my entire event log" every time);
+**PR 3's offline queue is correct by construction** (partial-success
+retries don't need bookkeeping).
+
+Contrast with **server-assigned IDs.** If `events.id` were a `bigserial`,
+the server would own identity. Push without IDs; server returns "here are
+the IDs we assigned." The retry case is now nasty: the client doesn't
+know if the previous push committed, so re-pushing inserts the same event
+twice with two different server-side IDs. To avoid that, you'd send a
+client-side dedupe key — which is just client-generated IDs, badly.
+
+UUIDs (v4 from `crypto.randomUUID()`) have 122 bits of randomness;
+collisions are practically impossible. The client synthesises them with
+no coordination; the server uses them directly as a primary key. The two
+ends of the pipe agree on identity without asking each other.
+
+The snapshot push (`src/lib/sync.ts:201-211`) is idempotent for a
+different reason: it's a single row keyed by `user_id`, and the upsert
+overwrites whatever was there. Same row state on every replay.
+
+> **General principle:** When client and server both refer to the same
+> entity, let the client generate the identifier. UUIDs make it safe.
+> Round-tripping for server-assigned IDs creates retry and
+> offline-emission problems with no clean solution.
+
+## The Sync Coordinator as a State Machine
+
+The coordinator is the most interesting file in the PR — auth events,
+store mutations, network calls, debouncing, and conflict detection all
+meet here. The good news: 260 lines, five states, three event sources.
+
+States: `'idle' | 'syncing' | 'saved' | 'error' | 'conflict-pending'`
+(`src/lib/sync-coordinator.ts:44`). Event sources:
+
+1. **Auth events** from `supabase.auth.onAuthStateChange`.
+2. **Store mutations** from `appState.subscribe`.
+3. **User decisions** from the conflict modal calling `resolveConflict`.
+
+The auth dispatcher (`src/lib/sync-coordinator.ts:109-130`):
+
+```ts
+async function handleAuthEvent(event: AuthChangeEvent, session: Session | null): Promise<void> {
+  currentSession = session;
+
+  if (event === 'SIGNED_OUT' || session === null) {
+    cancelPendingPush();
+    pendingConflictStore.set(null);
+    statusStore.set('idle');
+    return;
+  }
+
+  if (event === 'SIGNED_IN') {
+    await reconcileOnSignIn();
+    return;
+  }
+
+  if (event === 'INITIAL_SESSION') {
+    await silentPullIfPresent();
+    return;
+  }
+}
+```
+
+`INITIAL_SESSION` fires on page load with a cached session. Trust is
+high (the user was signed in last time); we silently pull and replace
+local. We _could_ peek-and-detect on every load, but that would punish
+the common path (single device, sign in once, use forever) for the edge
+case PR 3's offline queue addresses properly.
+
+`SIGNED_IN` fires on a fresh sign-in. Conflicts can exist here. Three
+branches (`src/lib/sync-coordinator.ts:132-161`):
+
+1. **Server empty, local anything.** Seed the server with local. Covers
+   "first sign-in ever."
+2. **Server has data, local empty.** Adopt the server. Covers "new
+   device, sign in for the first time."
+3. **Both have data.** Real conflict. Set `pendingConflictStore` to the
+   remote summary; the modal pops up; user picks.
+
+`peekRemoteState` (`src/lib/sync.ts:89-123`) is deliberately cheap —
+selects only the snapshot's `boxes`, `flavors`, `updated_at` and counts
+events via `head: true`. No event payloads. We save the full pull for
+after the user has chosen.
+
+`SIGNED_OUT` cancels pending pushes, clears the conflict store, returns
+to `idle`. Local data is left untouched — the user can keep using the
+app local-only.
+
+### `pendingConflict` as the single source of truth
+
+The conflict modal binds to `pendingConflict` directly
+(`src/lib/components/ConflictResolutionModal.svelte:64`):
+
+```svelte
+<Modal open={conflict !== null} title="Resolve data conflict" onclose={handleCancel}>
+```
+
+Modal visibility _is_ `$pendingConflict !== null`. There is no other
+boolean to track. There is no "is the modal open" state in the
+coordinator. **The store is the visibility state.**
+
+Why dwell on this? A common bug shape is "two pieces of state that need
+to agree but live in different places." Store says pending; modal opens.
+Modal closes; somebody has to clear the store. If either can change
+without the other, you have a bug. Making `pendingConflict` the single
+source of truth makes those bugs impossible.
+
+The `appState.subscribe` callback also reads it
+(`src/lib/sync-coordinator.ts:91-99`):
+
+```ts
+appState.subscribe((state) => {
+  if (suppressNextChange) {
+    suppressNextChange = false;
+    return;
+  }
+  if (!currentSession) return;
+  if (get(pendingConflictStore) !== null) return;
+  schedulePush(state);
+});
+```
+
+The third guard matters. While a conflict is pending, local mutations
+must _not_ push. Otherwise the user's eventual conflict decision could
+race with a mutation push and silently pick a side.
+
+## The Suppress-Outbound-Push Flag
+
+The gnarliest piece of state in the coordinator
+(`src/lib/sync-coordinator.ts:74`). A boolean module-level variable,
+set just before applying server state
+(`src/lib/sync-coordinator.ts:242-245`):
+
+```ts
+function applyServerState(state: AppState): void {
+  suppressNextChange = true;
+  replaceAppState(state);
+}
+```
+
+Consumed in the subscriber:
+
+```ts
+appState.subscribe((state) => {
+  if (suppressNextChange) {
+    suppressNextChange = false;
+    return;
+  }
+  // ...
+});
+```
+
+The problem this solves: when we pull from the server and call
+`replaceAppState(serverState)`, the store fires its subscribers — _including
+ours_. Without the flag, our subscriber would see "the local state just
+changed" and queue a push of the just-pulled data. That push would be
+harmless (idempotent), but it would burn a round-trip and confuse the
+status indicator. Worse, in PR 3's offline-queue future, it would write
+the pulled state to the outbound queue and re-push it forever on every
+reconnect.
+
+The flag is a one-shot signal: "the next store change is internally
+caused; ignore it." Set just before `replaceAppState`, clear inside the
+subscriber on the next fire.
+
+### Why a flag and not "compare and skip"?
+
+The cleaner-sounding alternative: in the subscriber, deep-compare the
+incoming state against the last-pulled state and skip on equality.
+Worse in three ways: deep equality runs on every mutation forever; it
+conflates "the data is the same" with "this change came from a pull"
+(a legitimate edit that round-trips back to identical state would be
+silently swallowed); identity-of-cause is conceptually what we want,
+not coincidence-of-result.
+
+The flag tells you _why_ the change happened. That distinction is what
+makes PR 3's offline queue safe.
+
+(Svelte's `writable` fires subscribers synchronously on `set`, so the
+"flag set but never consumed" case can't happen — `replaceAppState`
+calls `appState.set`, which fires synchronously before
+`applyServerState` returns.)
+
+> **General principle:** When you need to distinguish "I caused this
+> change" from "someone else caused this change," prefer an explicit
+> signal over inferring it from the data. The signal carries intent;
+> data-equality carries coincidence.
+
+## Debounced Push: Coalescing Without Losing (Much)
+
+Every local mutation calls `schedulePush`
+(`src/lib/sync-coordinator.ts:216-223`):
+
+```ts
+function schedulePush(state: AppState): void {
+  if (pushTimer) clearTimeout(pushTimer);
+  pushTimer = setTimeout(() => {
+    pushTimer = null;
+    void runPush(state);
+  }, pushDelayMs);
+  statusStore.set('syncing');
+}
+```
+
+`pushDelayMs` defaults to 2500. Each mutation cancels the prior timer
+and starts a new one. Only after mutations have stopped for 2.5 s does
+the push fire. Ten store updates from a drag-rearrange collapse into one
+network round-trip.
+
+Why 2.5 seconds? Nothing magic. The constraints: coalesce rapid edits
+(drag-rearrange fires ten updates a second); don't leave "syncing…"
+showing forever (1 s is too short for coalescing, 5 s leaves the
+indicator hanging); don't throttle instead of debounce (loses the "wait
+for quiet" property). 2.5 s was the sweet spot. The `setPushDelay` test
+hook (`src/lib/sync-coordinator.ts:105-107`) drops it to ~50 ms in unit
+tests.
+
+### What if the user closes the tab during the debounce window?
+
+Edit at T = 0; push scheduled for T = 2.5; tab closed at T = 1. The
+`setTimeout` fires never. The push is lost. The mutation is in local
+LocalStorage (the auto-save subscriber writes synchronously) but not on
+the server. Next launch, `INITIAL_SESSION` pulls the server state and
+the local edit is gone.
+
+That's a real bug. We accept it because the window is small (2.5 s) and
+it only matters in a narrow scenario (edit, immediately close tab,
+reopen on same or another device). PR 3's offline queue fixes it
+directly: un-acked edits persist in LocalStorage and push on the next
+session.
+
+A `beforeunload` flush would help but `fetch` inside `beforeunload` is
+unreliable across browsers (sync XHR deprecated; `sendBeacon` doesn't
+fit our payload shape). Partial reliability is worse than honest absence
+— users trust a "saved" indicator more than they trust the absence of
+a save. Better to wait for the proper fix.
+
+> **General principle:** Debouncing trades fewer writes for
+> data-loss-on-shutdown. Keep the window small enough that "I just lost
+> my last edit" is rare; document the gap rather than papering over it
+> with unreliable `beforeunload` hacks.
+
+## Graceful Degradation When Env Vars Are Missing
+
+A small choice with outsized effect on contributor experience.
+`src/lib/supabase.ts:25-41`:
+
+```ts
+export const supabase: SupabaseClient | null =
+  url && anonKey
+    ? createClient(url, anonKey, {
+        /* ... */
+      })
+    : null;
+```
+
+`supabase` is `SupabaseClient | null`. Missing env vars produce `null`,
+not a half-configured client, not a thrown error at module load. Every
+downstream caller checks for `null`:
+
+- `src/lib/sync.ts:68-73` — `requireClient` throws a `SyncError`.
+- `src/lib/auth.ts:75` — `sendMagicLink` throws `SyncNotConfiguredError`.
+- `src/lib/sync-coordinator.ts:84` — `initializeSync` returns early.
+- `src/lib/components/SyncAccountModal.svelte:95` — `isSyncConfigured()`
+  in the template renders a "not configured" notice instead of the
+  sign-in form.
+
+A contributor who clones the repo without filling in `.env.local` gets a
+fully functional local-only app. Inventory works, random selection
+works, backup works. The only thing that doesn't is sync, and the Sync
+modal explains why.
+
+Three properties worth being explicit about. **No crash on missing env
+vars** — throwing at module load is fine for a deployed build (env vars
+set in the hosting platform) but hostile to anyone running the dev
+server for the first time, and it crashes the _entire_ app because that
+import is near the top of the dependency graph. **No fake sync that
+silently fails** — stubbing out the client with no-ops so calls
+"succeed" produces "I hit Send and nothing happened," which is far worse
+UX than an explicit notice. **Type system carries the maybe-ness** —
+`SupabaseClient | null` forces every caller to narrow or assert; the
+language helps you not forget.
+
+We considered abstracting the null check into a `withClient(fn)` helper
+but decided the repetition was honest. Each caller makes a different
+decision (throw, return early, render different UI). One abstraction
+wouldn't capture all of them cleanly.
+
+## Conflict Resolution: Three Explicit Branches
+
+`resolveConflict` has three values
+(`src/lib/sync-coordinator.ts:182-214`). `cancel` signs out and clears
+local state. `keep-local` clears the server and re-pushes local.
+`keep-server` pulls the server and replaces local. The modal calls into
+it via `handleContinue` / `handleCancel`
+(`src/lib/components/ConflictResolutionModal.svelte:45-61`).
+
+### Why no auto-merge
+
+Auto-merging two devices' inventories sounds great until you write it
+down. If device A has a box of chocolate at location (0, 2) and device B
+has a different box at (0, 2), what's the merged answer? "Both" puts
+two boxes at the same coordinates, which the UI can't render. Override
+one — which? The freshest? Timestamps from two devices aren't
+necessarily comparable. Pick the larger inventory? Arbitrary.
+
+The honest answer is "this needs CRDTs or per-field merge rules, which
+are PR 3." For PR 2, we don't pretend. We make the user pick and we
+tell them clearly what each side looks like (box count, last-change
+time, event count). Same instinct as PR 1's "no synthetic backfill":
+discipline about uncertainty rather than guessing.
+
+### Why `cancel` signs out
+
+Cancel signs out. Not "dismiss the modal." Not "leave the conflict
+pending and let me think later."
+
+The alternative would leave the coordinator in `conflict-pending` with
+no UI showing the conflict. The user is signed in but the coordinator
+refuses to push (the `pendingConflict` guard). Every edit silently
+doesn't sync; the status indicator is wrong. Confusing limbo.
+
+Signing out cleanly reverts to local-only. No pending sync. No data
+touched on either side. The button label "Cancel sign-in" is also more
+honest than "Maybe later" — it says exactly what's about to happen.
+
+### Why `keep-local` clears the server first
+
+`keep-local` calls `clearRemoteState()` before `pushFullState`. Why not
+just push? Upsert overwrites the snapshot anyway, and event IDs are
+idempotent.
+
+The issue is event _absence_. Server has 50 events from another device;
+local has 30 different events; pushing local upserts the snapshot
+(good) and inserts the 30 events (server now has 80 = 50 + 30). The
+user said "keep this device." They expect the timeline _on this
+device_. They don't expect this-device-plus-the-other-device's-history.
+Without the clear, "keep-local" would actually be "merge events, snapshot
+last-write-wins" — a third semantic that doesn't match what the modal
+said.
+
+Clear-then-push gives literal-meaning semantics: after the resolve, the
+server matches this device exactly.
+
+### Branch summary
+
+| Choice        | Server             | Local            | After           |
+| ------------- | ------------------ | ---------------- | --------------- |
+| `keep-local`  | wiped, then pushed | unchanged        | server == local |
+| `keep-server` | unchanged          | replaced by pull | local == server |
+| `cancel`      | unchanged          | unchanged        | signed out      |
+
+Every choice is total and explicit. The destructive ones
+(`keep-local`, `keep-server`) destroy exactly the side the user asked
+to overwrite, after the modal has shown them what's at stake.
+
+## What We Deliberately Did NOT Do
+
+PR 3 picks most of these up. Listed so future you doesn't wonder if
+they were forgotten.
+
+- **No realtime subscriptions.** Server changes don't push to other
+  devices. The schema is shaped to enable this in PR 3 — `events` is a
+  natural Realtime source.
+- **No offline queue.** Pushes fail when offline; status goes to
+  `error` and stops trying. PR 3 will persist un-acked events and drain
+  on reconnect.
+- **No CRDT or field-level merge.** Two devices editing simultaneously
+  can clobber each other's snapshot (last-write-wins). PR 3 will
+  field-level merge for at least `favoriteFlavorId` and box locations.
+- **No required sign-in.** Sign-in stays optional. The app remains fully
+  usable signed-out. Preserves the daily-use mode.
+- **No event-by-event streaming.** Push is always "full event list,
+  idempotently upserted." One HTTP per debounce window, not one HTTP per
+  event.
+- **No encrypted-at-rest data.** Server data is clear Postgres JSONB.
+  RLS keeps it owner-only, but Supabase staff with database access could
+  read it. Fine for protein-shake inventory; a health-data app would
+  need to revisit.
+- **No custom auth UI screens.** One modal with two states (in / out)
+  plus a not-configured notice. No "Reset password," no "Verify email,"
+  no SSO buttons. Supabase ships auth UI components; we chose to roll
+  our own because the surface is small.
+- **No telemetry on sync.** Errors live in `lastErrorStore` and
+  `console.error`. Good enough for one user.
+
+## Further Reading
+
+- ADR-012: Supabase-Backed Sync with Magic-Link Auth — the decision
+  record for this PR.
+- ADR-011: Local Event Timeline (PR 1) — the foundation this PR builds
+  on. Read first if you haven't.
+- `docs/teaching/1.6-event-timeline-design.md` — the predecessor doc.
+  The "designed for sync" section describes the hooks this PR consumes.
+- `docs/teaching/1.5-svelte-stores-localstorage.md` — the auto-save
+  pattern that the coordinator extends with debounced server push.
+- `docs/teaching/3.6-json-file-backup-pattern.md` — the "validate at
+  the boundary" pattern that `pullFullState` reuses.
+- [Supabase: Row Level Security](https://supabase.com/docs/guides/auth/row-level-security)
+  — the canonical docs for the policy DSL.
+- [Supabase: Auth — Magic Links](https://supabase.com/docs/guides/auth/auth-magic-link)
+  — passwordless auth via OTP.
+- [RFC 7636: PKCE](https://datatracker.ietf.org/doc/html/rfc7636) — the
+  authoritative spec for the proof-key flow.
+- [Martin Kleppmann on CRDTs](https://crdt.tech/) — vocabulary for PR 3.
+- [Lamport timestamps](https://lamport.azurewebsites.net/pubs/time-clocks.pdf)
+  — logical clocks for ordering events across devices without a
+  central authority. PR 3 may extend `event_timestamp` with Lamport
+  ordering for the "two devices, same millisecond" case.
+- [Supabase Realtime](https://supabase.com/docs/guides/realtime) — the
+  primitive PR 3 will subscribe to.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "temp-init",
       "version": "0.0.0",
       "dependencies": {
+        "@supabase/supabase-js": "^2.105.4",
         "svelte-dnd-action": "^0.9.69",
         "svelte-spa-router": "^5.0.0"
       },
@@ -3108,6 +3109,90 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.105.4",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.105.4.tgz",
+      "integrity": "sha512-Ejfa37M5xoIwoxVebxRahnwubPo8g22qkXQ4p50+N9MIvU9UZoN+A8dwVPtczzGf8oV/YXN80ZPxK4aWXuSN/A==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.105.4",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.105.4.tgz",
+      "integrity": "sha512-JVNKbBft3Qkja+WlGaE026AJ2AH9K0UTsxsfvEIHgd4zFrBor4BYRCrYFrv9IDsvVqkF72wKDsODJl5GY/C4tA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.2.tgz",
+      "integrity": "sha512-YSAGnmDAfuleFCVt3CeurQZAhxRfXWeZIIkwp7NhYzQ1UwW6ePSnzsFAiUm/mbCkfoCf70QQHKW/K6RKh52a4A==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.105.4",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.105.4.tgz",
+      "integrity": "sha512-SppIyLo/kTwIlz1qpv2HN1EQqBg0GVktrDDFsXygYROha3MgVn4rT7p5EjFHFqXQm2rdRGb/BI7bc+jr10m91w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.105.4",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.105.4.tgz",
+      "integrity": "sha512-6ov6c59+8D9h7q4M4Gy/uDJlC0Akxl9/714Y+6vJ+Sijuc16TS/p5DwhfRCLNcIhNiej1gEt+CQUwsjiPt4PxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "^0.4.2",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.105.4",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.105.4.tgz",
+      "integrity": "sha512-Jx+pzMP1Whjof2PWHoVBUA75/p7PQE9CqKBzn1oXVyJDOggMLSH2OzVWwsXYaxEpdC1K/KltwmOX44nL3LHl9g==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.105.4",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.105.4.tgz",
+      "integrity": "sha512-cEnx+k49knU+qdIP7rXwR6fqEXPHZs+74xFK1R0S8MgQ7v9tbePVdGxvO03n3bPympMdJWVLadARBfU4TgNHCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.105.4",
+        "@supabase/functions-js": "2.105.4",
+        "@supabase/postgrest-js": "2.105.4",
+        "@supabase/realtime-js": "2.105.4",
+        "@supabase/storage-js": "2.105.4"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/@surma/rollup-plugin-off-main-thread": {
       "version": "2.2.3",
@@ -6644,6 +6729,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"
+      }
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/iconv-lite": {
@@ -10261,7 +10355,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     ]
   },
   "dependencies": {
+    "@supabase/supabase-js": "^2.105.4",
     "svelte-dnd-action": "^0.9.69",
     "svelte-spa-router": "^5.0.0"
   },

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -16,6 +16,8 @@
   import Router, { router } from 'svelte-spa-router';
   import { routes } from './lib/router/routes';
   import WelcomeModal from './lib/components/WelcomeModal.svelte';
+  import ConflictResolutionModal from './lib/components/ConflictResolutionModal.svelte';
+  import { initializeSync } from './lib/sync-coordinator';
   import { onMount } from 'svelte';
 
   /**
@@ -40,13 +42,15 @@
   };
 
   /**
-   * Check if this is the first visit and show welcome modal
+   * Check if this is the first visit and show welcome modal.
+   * Also wires up the Supabase sync coordinator (no-op when not configured).
    */
   onMount(() => {
     const hasSeenWelcome = localStorage.getItem(WELCOME_SHOWN_KEY);
     if (!hasSeenWelcome) {
       showWelcomeModal = true;
     }
+    initializeSync();
   });
 
   /**
@@ -93,6 +97,10 @@
 
 <!-- Welcome Modal (first-time users) -->
 <WelcomeModal open={showWelcomeModal} onclose={handleWelcomeClose} />
+
+<!-- Sign-in conflict resolution. Modal opens itself when the coordinator
+     surfaces a pending conflict; renders nothing otherwise. -->
+<ConflictResolutionModal />
 
 <style>
   /**

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,111 @@
+/**
+ * Magic-link authentication for BroteinBuddy.
+ *
+ * Wraps Supabase Auth so the rest of the app deals with a small, opinionated
+ * surface: send a magic link, observe the session, sign out. The session is
+ * exposed as a Svelte store so components can react to sign-in / sign-out
+ * with the usual `$session` syntax.
+ *
+ * @module lib/auth
+ */
+
+import { writable, type Readable } from 'svelte/store';
+import type { Session } from '@supabase/supabase-js';
+import { supabase } from './supabase';
+
+/**
+ * Error thrown when an auth action is attempted but Supabase is not
+ * configured for this build (env vars missing).
+ */
+export class SyncNotConfiguredError extends Error {
+  constructor() {
+    super('Sync is not configured. Set VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY.');
+    this.name = 'SyncNotConfiguredError';
+  }
+}
+
+/**
+ * Error thrown when Supabase Auth rejects an action (bad email, rate limit,
+ * etc). Wraps the underlying message so the UI can surface it.
+ */
+export class AuthError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AuthError';
+  }
+}
+
+const sessionStore = writable<Session | null>(null);
+
+/**
+ * Reactive store of the current Supabase session, or `null` when signed
+ * out. Subscribers receive an update whenever the session changes — sign-in
+ * via magic link, token refresh, or sign-out.
+ *
+ * The store is hydrated synchronously on module load with whatever
+ * supabase-js has cached in localStorage, then kept in sync via the
+ * `onAuthStateChange` subscription.
+ */
+export const session: Readable<Session | null> = { subscribe: sessionStore.subscribe };
+
+if (supabase) {
+  // Hydrate from cache (resolves asynchronously but the store starts at
+  // null, which is the right default).
+  void supabase.auth.getSession().then(({ data }) => {
+    sessionStore.set(data.session);
+  });
+
+  supabase.auth.onAuthStateChange((_event, newSession) => {
+    sessionStore.set(newSession);
+  });
+}
+
+/**
+ * Sends a magic-link email to `email`. Clicking the link returns the user
+ * to the app and supabase-js automatically finalizes the session.
+ *
+ * Resolves when the email has been queued by Supabase. Throws
+ * {@link SyncNotConfiguredError} if env vars are missing or
+ * {@link AuthError} on a Supabase error.
+ *
+ * @param email - The address to send the link to. Trimmed; format validation
+ *   is delegated to Supabase.
+ */
+export async function sendMagicLink(email: string): Promise<void> {
+  if (!supabase) throw new SyncNotConfiguredError();
+
+  const trimmed = email.trim();
+  if (trimmed.length === 0) {
+    throw new AuthError('Email address is required.');
+  }
+
+  const { error } = await supabase.auth.signInWithOtp({
+    email: trimmed,
+    options: {
+      // The magic link redirects here; supabase-js parses the URL on load.
+      emailRedirectTo: window.location.origin,
+      // Don't auto-create accounts is the default; we override to allow it
+      // so the first sign-in for a new email seeds an auth.users row.
+      shouldCreateUser: true,
+    },
+  });
+
+  if (error) {
+    throw new AuthError(error.message);
+  }
+}
+
+/**
+ * Signs out of Supabase, clearing the cached session.
+ *
+ * Throws {@link SyncNotConfiguredError} if env vars are missing or
+ * {@link AuthError} on a Supabase error.
+ */
+export async function signOut(): Promise<void> {
+  if (!supabase) throw new SyncNotConfiguredError();
+
+  const { error } = await supabase.auth.signOut();
+  if (error) {
+    throw new AuthError(error.message);
+  }
+}

--- a/src/lib/components/ConflictResolutionModal.svelte
+++ b/src/lib/components/ConflictResolutionModal.svelte
@@ -1,0 +1,199 @@
+<script lang="ts">
+  /**
+   * Sign-in conflict resolution modal.
+   *
+   * Mounted globally and bound to `pendingConflict` from the sync
+   * coordinator. When non-null, both the local device and the server have
+   * non-trivial inventory; the user picks which side wins. The decision is
+   * passed back to the coordinator via `resolveConflict`.
+   *
+   * @component
+   */
+
+  import Button from './Button.svelte';
+  import Modal from './Modal.svelte';
+  import { appState } from '$lib/stores';
+  import { pendingConflict, resolveConflict } from '$lib/sync-coordinator';
+
+  let choice = $state<'keep-local' | 'keep-server'>('keep-local');
+  let busy = $state(false);
+
+  let conflict = $derived($pendingConflict);
+  let local = $derived($appState);
+
+  let localBoxCount = $derived(local.boxes.length);
+  let localOpenBoxes = $derived(local.boxes.filter((b) => b.isOpen).length);
+  let localEventCount = $derived(local.events.length);
+
+  let serverBoxCount = $derived(conflict?.boxCount ?? 0);
+  let serverEventCount = $derived(conflict?.eventCount ?? 0);
+
+  function formatServerUpdate(timestamp: string | null | undefined): string {
+    if (!timestamp) return 'unknown';
+    const date = new Date(timestamp);
+    if (Number.isNaN(date.getTime())) return 'unknown';
+    const diffMs = Date.now() - date.getTime();
+    const minutes = Math.floor(diffMs / 60_000);
+    if (minutes < 1) return 'just now';
+    if (minutes < 60) return `${minutes}m ago`;
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) return `${hours}h ago`;
+    const days = Math.floor(hours / 24);
+    return `${days}d ago`;
+  }
+
+  async function handleContinue() {
+    busy = true;
+    try {
+      await resolveConflict(choice);
+    } finally {
+      busy = false;
+    }
+  }
+
+  async function handleCancel() {
+    busy = true;
+    try {
+      await resolveConflict('cancel');
+    } finally {
+      busy = false;
+    }
+  }
+</script>
+
+<Modal open={conflict !== null} title="Resolve data conflict" onclose={handleCancel}>
+  {#if conflict}
+    <div class="conflict">
+      <p class="explainer">
+        Both this device and the server have inventory data. Pick which one to keep — the other will
+        be replaced.
+      </p>
+
+      <div class="options" role="radiogroup" aria-label="Conflict resolution choice">
+        <label class="option" class:selected={choice === 'keep-local'}>
+          <input
+            type="radio"
+            name="conflict-choice"
+            value="keep-local"
+            bind:group={choice}
+            disabled={busy}
+            data-testid="conflict-modal-keep-local"
+          />
+          <div class="option-body">
+            <strong>Keep this device</strong>
+            <p>
+              {localBoxCount} box{localBoxCount === 1 ? '' : 'es'}
+              ({localOpenBoxes} open), {localEventCount} timeline event{localEventCount === 1
+                ? ''
+                : 's'}.
+            </p>
+          </div>
+        </label>
+
+        <label class="option" class:selected={choice === 'keep-server'}>
+          <input
+            type="radio"
+            name="conflict-choice"
+            value="keep-server"
+            bind:group={choice}
+            disabled={busy}
+            data-testid="conflict-modal-keep-server"
+          />
+          <div class="option-body">
+            <strong>Keep server</strong>
+            <p>
+              {serverBoxCount} box{serverBoxCount === 1 ? '' : 'es'}, {serverEventCount} timeline event{serverEventCount ===
+              1
+                ? ''
+                : 's'}. Last change
+              {formatServerUpdate(conflict.updatedAt)}.
+            </p>
+          </div>
+        </label>
+      </div>
+
+      <div class="actions">
+        <Button
+          variant="ghost"
+          size="base"
+          onclick={handleCancel}
+          disabled={busy}
+          testId="conflict-modal-cancel"
+        >
+          Cancel sign-in
+        </Button>
+        <Button
+          variant="primary"
+          size="base"
+          onclick={handleContinue}
+          disabled={busy}
+          testId="conflict-modal-continue"
+        >
+          {busy ? 'Working…' : 'Continue'}
+        </Button>
+      </div>
+    </div>
+  {/if}
+</Modal>
+
+<style>
+  .conflict {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4);
+  }
+
+  .explainer {
+    margin: 0;
+    color: var(--color-text-secondary);
+    line-height: 1.5;
+  }
+
+  .options {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+  }
+
+  .option {
+    display: flex;
+    gap: var(--space-3);
+    align-items: flex-start;
+    padding: var(--space-3);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-base);
+    cursor: pointer;
+    transition: border-color 0.15s ease;
+  }
+
+  .option.selected {
+    border-color: var(--color-primary);
+    background: var(--color-background-secondary);
+  }
+
+  .option input {
+    margin-top: 4px;
+  }
+
+  .option-body {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+  }
+
+  .option-body strong {
+    color: var(--color-text-primary);
+  }
+
+  .option-body p {
+    margin: 0;
+    color: var(--color-text-secondary);
+    font-size: var(--font-size-sm);
+  }
+
+  .actions {
+    display: flex;
+    gap: var(--space-3);
+    justify-content: flex-end;
+  }
+</style>

--- a/src/lib/components/SyncAccountModal.svelte
+++ b/src/lib/components/SyncAccountModal.svelte
@@ -1,0 +1,259 @@
+<script lang="ts">
+  /**
+   * Sync & Account modal.
+   *
+   * Two states, switched by the current Supabase session:
+   *   - Signed out: email input + "Send magic link" button.
+   *   - Signed in:  email display + last-synced timestamp + sign-out button.
+   *
+   * The modal does not own the sync state machine — it just observes the
+   * stores from `lib/sync-coordinator` and the `session` store from
+   * `lib/auth`. The coordinator handles push/pull and conflict resolution
+   * on its own.
+   *
+   * @component
+   */
+
+  import Button from './Button.svelte';
+  import Modal from './Modal.svelte';
+  import { session, sendMagicLink, signOut, AuthError, SyncNotConfiguredError } from '$lib/auth';
+  import { syncStatus, lastSyncedAt, lastError } from '$lib/sync-coordinator';
+  import { isSyncConfigured } from '$lib/supabase';
+
+  interface Props {
+    open: boolean;
+    onclose: () => void;
+  }
+
+  let { open, onclose }: Props = $props();
+
+  let email = $state('');
+  let stage = $state<'idle' | 'sending' | 'sent' | 'error'>('idle');
+  let errorMessage = $state('');
+
+  $effect(() => {
+    if (!open) {
+      stage = 'idle';
+      errorMessage = '';
+    }
+  });
+
+  async function handleSendLink() {
+    stage = 'sending';
+    errorMessage = '';
+    try {
+      await sendMagicLink(email);
+      stage = 'sent';
+    } catch (err) {
+      stage = 'error';
+      errorMessage =
+        err instanceof AuthError || err instanceof SyncNotConfiguredError
+          ? err.message
+          : 'Failed to send magic link.';
+    }
+  }
+
+  async function handleSignOut() {
+    try {
+      await signOut();
+    } catch (err) {
+      errorMessage = err instanceof Error ? err.message : 'Sign out failed.';
+    }
+  }
+
+  function formatRelative(date: Date | null): string {
+    if (!date) return 'never';
+    const diffMs = Date.now() - date.getTime();
+    const seconds = Math.floor(diffMs / 1000);
+    if (seconds < 5) return 'just now';
+    if (seconds < 60) return `${seconds}s ago`;
+    const minutes = Math.floor(seconds / 60);
+    if (minutes < 60) return `${minutes}m ago`;
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) return `${hours}h ago`;
+    const days = Math.floor(hours / 24);
+    return `${days}d ago`;
+  }
+
+  function statusLabel(status: typeof $syncStatus): string {
+    switch (status) {
+      case 'idle':
+        return 'Idle';
+      case 'syncing':
+        return 'Syncing…';
+      case 'saved':
+        return 'Saved';
+      case 'error':
+        return 'Error';
+      case 'conflict-pending':
+        return 'Waiting on conflict resolution';
+    }
+  }
+</script>
+
+<Modal {open} title="Sync & Account" {onclose}>
+  {#if !isSyncConfigured()}
+    <div class="not-configured">
+      <p>
+        Sync is not configured for this build. Set <code>VITE_SUPABASE_URL</code> and
+        <code>VITE_SUPABASE_ANON_KEY</code> in <code>.env.local</code> (see
+        <code>supabase/README.md</code>) to enable multi-device sync.
+      </p>
+    </div>
+  {:else if $session === null}
+    <div class="signed-out">
+      <p class="explainer">
+        Sign in to sync inventory across your devices. Type your email and we'll send a one-tap
+        magic link — no password.
+      </p>
+
+      <label class="field">
+        <span>Email</span>
+        <input
+          type="email"
+          bind:value={email}
+          placeholder="you@example.com"
+          disabled={stage === 'sending'}
+          autocomplete="email"
+          data-testid="sync-modal-email-input"
+        />
+      </label>
+
+      {#if stage === 'sent'}
+        <p class="success" role="status">
+          Magic link sent. Check your inbox and click the link to sign in.
+        </p>
+      {:else if stage === 'error'}
+        <p class="error" role="alert">{errorMessage}</p>
+      {/if}
+
+      <div class="actions">
+        <Button
+          variant="primary"
+          size="base"
+          disabled={stage === 'sending' || email.trim().length === 0}
+          onclick={handleSendLink}
+          testId="sync-modal-send-link-button"
+        >
+          {stage === 'sending' ? 'Sending…' : 'Send magic link'}
+        </Button>
+        <Button variant="ghost" size="base" onclick={onclose}>Close</Button>
+      </div>
+    </div>
+  {:else}
+    <div class="signed-in">
+      <p class="explainer">Signed in as <strong>{$session.user.email}</strong></p>
+
+      <dl class="status-grid">
+        <dt>Status</dt>
+        <dd data-testid="sync-modal-status">{statusLabel($syncStatus)}</dd>
+        <dt>Last synced</dt>
+        <dd>{formatRelative($lastSyncedAt)}</dd>
+      </dl>
+
+      {#if $lastError}
+        <p class="error" role="alert">{$lastError}</p>
+      {/if}
+
+      <div class="actions">
+        <Button
+          variant="danger"
+          size="base"
+          onclick={handleSignOut}
+          testId="sync-modal-sign-out-button"
+        >
+          Sign out
+        </Button>
+        <Button variant="ghost" size="base" onclick={onclose}>Close</Button>
+      </div>
+    </div>
+  {/if}
+</Modal>
+
+<style>
+  .signed-out,
+  .signed-in,
+  .not-configured {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4);
+    padding: var(--space-2) 0;
+  }
+
+  .explainer {
+    margin: 0;
+    color: var(--color-text-secondary);
+    line-height: 1.5;
+  }
+
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+  }
+
+  .field span {
+    font-weight: var(--font-weight-medium);
+    color: var(--color-text-primary);
+  }
+
+  .field input {
+    padding: var(--space-3);
+    font-size: var(--font-size-base);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-base);
+    background: var(--color-background);
+    color: var(--color-text-primary);
+  }
+
+  .field input:focus {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 1px;
+  }
+
+  .success {
+    margin: 0;
+    color: var(--color-success-dark);
+    background: var(--color-success-bg);
+    padding: var(--space-3);
+    border-radius: var(--radius-base);
+  }
+
+  .error {
+    margin: 0;
+    color: var(--color-danger-dark);
+    background: var(--color-danger-bg);
+    padding: var(--space-3);
+    border-radius: var(--radius-base);
+  }
+
+  .status-grid {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: var(--space-2) var(--space-4);
+    margin: 0;
+  }
+
+  .status-grid dt {
+    color: var(--color-text-secondary);
+  }
+
+  .status-grid dd {
+    margin: 0;
+    color: var(--color-text-primary);
+  }
+
+  .actions {
+    display: flex;
+    gap: var(--space-3);
+    justify-content: flex-end;
+    margin-top: var(--space-2);
+  }
+
+  code {
+    background: var(--color-background-secondary);
+    padding: 0 var(--space-1);
+    border-radius: var(--radius-sm);
+    font-size: 0.95em;
+  }
+</style>

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,0 +1,50 @@
+/**
+ * Supabase client singleton.
+ *
+ * Reads connection info from Vite env vars at build time. When the vars are
+ * missing (e.g. a contributor cloned the repo without configuring
+ * `.env.local`) the module exports `null` so the rest of the app can detect
+ * a "sync disabled" state and skip every Supabase call. This is preferable
+ * to crashing on import.
+ *
+ * @module lib/supabase
+ */
+
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+
+const url = import.meta.env.VITE_SUPABASE_URL as string | undefined;
+const anonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined;
+
+/**
+ * The configured Supabase client, or `null` if env vars are missing.
+ *
+ * Callers should treat `null` as "sync is not available in this build" —
+ * fall back to the existing LocalStorage-only flow without surfacing an
+ * error.
+ */
+export const supabase: SupabaseClient | null =
+  url && anonKey
+    ? createClient(url, anonKey, {
+        auth: {
+          // Persist the session in localStorage so the user stays signed
+          // in across reloads. supabase-js handles the storage key.
+          persistSession: true,
+          // Read the magic-link tokens from the URL on app load and finalize
+          // the session automatically; we don't need a dedicated callback
+          // route.
+          detectSessionInUrl: true,
+          // Refresh the access token automatically just before expiry.
+          autoRefreshToken: true,
+          flowType: 'pkce',
+        },
+      })
+    : null;
+
+/**
+ * Convenience for places that need to short-circuit when Supabase isn't
+ * configured. Lets callers `if (!isSyncConfigured()) return` without
+ * narrowing the SupabaseClient type by hand.
+ */
+export function isSyncConfigured(): boolean {
+  return supabase !== null;
+}

--- a/src/lib/sync-coordinator.ts
+++ b/src/lib/sync-coordinator.ts
@@ -76,6 +76,16 @@ let currentSession: Session | null = null;
 let conflictLocalSnapshot: AppState | null = null;
 
 /**
+ * Promise chain that serializes auth-event handling. supabase-js fires
+ * INITIAL_SESSION and SIGNED_IN back-to-back when a magic link is clicked
+ * on a device that already has a cached session; without serialization
+ * the two `async` handlers race and a slow pull can land after a fast
+ * conflict resolution, corrupting state. Each new event awaits the
+ * previous handler before its own work begins.
+ */
+let authEventQueue: Promise<void> = Promise.resolve();
+
+/**
  * Wires the coordinator to auth + store events. Call once at app boot.
  * Subsequent calls are no-ops.
  */
@@ -85,7 +95,13 @@ export function initializeSync(): void {
   initialized = true;
 
   supabase.auth.onAuthStateChange((event, session) => {
-    handleAuthEvent(event, session).catch((err) => recordError(err));
+    authEventQueue = authEventQueue
+      .catch(() => {
+        // Swallow earlier errors so they don't poison the chain — they're
+        // already surfaced via recordError on the previous tick.
+      })
+      .then(() => handleAuthEvent(event, session))
+      .catch((err) => recordError(err));
   });
 
   appState.subscribe((state) => {

--- a/src/lib/sync-coordinator.ts
+++ b/src/lib/sync-coordinator.ts
@@ -1,0 +1,263 @@
+/**
+ * Sync coordinator: wires the local Svelte store to the Supabase backend.
+ *
+ * Public surface:
+ *   - `initializeSync()` — call once at app boot. Idempotent.
+ *   - `syncStatus`, `lastSyncedAt`, `pendingConflict` — readable stores for
+ *     the UI to drive the status indicator and conflict modal.
+ *   - `resolveConflict(choice)` — called by the conflict modal when the
+ *     user picks a side.
+ *
+ * Behaviour:
+ *   - On page load with an existing session: silently pull the server state
+ *     and replace local. (INITIAL_SESSION auth event.)
+ *   - On fresh sign-in (SIGNED_IN auth event): peek at the server.
+ *     If both sides have data, surface a conflict for the modal to resolve.
+ *     Otherwise push (seed empty server) or pull (replace empty local).
+ *   - While signed in: debounced push of the full state on every local
+ *     mutation. Default debounce is 2.5 s; tunable via `setPushDelay()` for
+ *     tests.
+ *   - On sign-out: cancel pending pushes; status -> 'idle'.
+ *
+ * Out of scope for PR 2 (lives in PR 3):
+ *   - Realtime subscribe to server-side changes
+ *   - Offline queue / retry-on-reconnect
+ *   - Field-level merge / CRDT
+ *
+ * @module lib/sync-coordinator
+ */
+
+import { writable, get, type Readable } from 'svelte/store';
+import type { AuthChangeEvent, Session } from '@supabase/supabase-js';
+import { supabase, isSyncConfigured } from './supabase';
+import { appState, replaceAppState } from './stores';
+import {
+  pushFullState,
+  pullFullState,
+  peekRemoteState,
+  clearRemoteState,
+  SyncError,
+  type RemoteStateSummary,
+} from './sync';
+import type { AppState } from '../types/models';
+
+export type SyncStatus = 'idle' | 'syncing' | 'saved' | 'error' | 'conflict-pending';
+
+const statusStore = writable<SyncStatus>('idle');
+const lastSyncedAtStore = writable<Date | null>(null);
+const pendingConflictStore = writable<RemoteStateSummary | null>(null);
+const lastErrorStore = writable<string | null>(null);
+
+/**
+ * Current sync status. Drives the small Saved / Syncing… indicator and
+ * the conflict modal visibility (`conflict-pending`).
+ */
+export const syncStatus: Readable<SyncStatus> = { subscribe: statusStore.subscribe };
+
+/** When the last successful push or pull completed. */
+export const lastSyncedAt: Readable<Date | null> = { subscribe: lastSyncedAtStore.subscribe };
+
+/**
+ * Non-null when the sign-in flow detected data on both sides and is
+ * waiting for the user to choose. The modal subscribes to this.
+ */
+export const pendingConflict: Readable<RemoteStateSummary | null> = {
+  subscribe: pendingConflictStore.subscribe,
+};
+
+/** Last sync error message, or null. UI may surface in the indicator. */
+export const lastError: Readable<string | null> = { subscribe: lastErrorStore.subscribe };
+
+let initialized = false;
+let pushDelayMs = 2500;
+let pushTimer: ReturnType<typeof setTimeout> | null = null;
+let suppressNextChange = false;
+let currentSession: Session | null = null;
+let conflictLocalSnapshot: AppState | null = null;
+
+/**
+ * Wires the coordinator to auth + store events. Call once at app boot.
+ * Subsequent calls are no-ops.
+ */
+export function initializeSync(): void {
+  if (initialized) return;
+  if (!isSyncConfigured() || !supabase) return;
+  initialized = true;
+
+  supabase.auth.onAuthStateChange((event, session) => {
+    handleAuthEvent(event, session).catch((err) => recordError(err));
+  });
+
+  appState.subscribe((state) => {
+    if (suppressNextChange) {
+      suppressNextChange = false;
+      return;
+    }
+    if (!currentSession) return;
+    if (get(pendingConflictStore) !== null) return;
+    schedulePush(state);
+  });
+}
+
+/**
+ * Test hook: override the push debounce. Real code uses the default 2.5 s.
+ */
+export function setPushDelay(ms: number): void {
+  pushDelayMs = ms;
+}
+
+async function handleAuthEvent(event: AuthChangeEvent, session: Session | null): Promise<void> {
+  currentSession = session;
+
+  if (event === 'SIGNED_OUT' || session === null) {
+    cancelPendingPush();
+    pendingConflictStore.set(null);
+    statusStore.set('idle');
+    return;
+  }
+
+  if (event === 'SIGNED_IN') {
+    await reconcileOnSignIn();
+    return;
+  }
+
+  if (event === 'INITIAL_SESSION') {
+    await silentPullIfPresent();
+    return;
+  }
+
+  // TOKEN_REFRESHED, USER_UPDATED, etc. — no sync action needed.
+}
+
+async function reconcileOnSignIn(): Promise<void> {
+  statusStore.set('syncing');
+  try {
+    const remote = await peekRemoteState();
+    const local = get(appState);
+
+    if (!remote.exists) {
+      // Server is empty — seed it from whatever we have locally (even if
+      // local is also empty, the push creates the row).
+      await pushFullState(local);
+      markSynced();
+      return;
+    }
+
+    if (isLocallyEmpty(local)) {
+      // Server has data, local is fresh — adopt the server.
+      const pulled = await pullFullState();
+      if (pulled) applyServerState(pulled);
+      markSynced();
+      return;
+    }
+
+    // Both sides have data: pause and let the UI present a chooser.
+    conflictLocalSnapshot = local;
+    pendingConflictStore.set(remote);
+    statusStore.set('conflict-pending');
+  } catch (err) {
+    recordError(err);
+  }
+}
+
+async function silentPullIfPresent(): Promise<void> {
+  if (!currentSession) return;
+  statusStore.set('syncing');
+  try {
+    const pulled = await pullFullState();
+    if (pulled) applyServerState(pulled);
+    markSynced();
+  } catch (err) {
+    recordError(err);
+  }
+}
+
+/**
+ * Resolves a pending sign-in conflict. Called by the conflict modal.
+ *
+ * - `keep-local` wipes the server and re-pushes local.
+ * - `keep-server` replaces local with the server state.
+ * - `cancel` signs out so no data is touched.
+ */
+export async function resolveConflict(
+  choice: 'keep-local' | 'keep-server' | 'cancel'
+): Promise<void> {
+  const summary = get(pendingConflictStore);
+  if (!summary) return;
+
+  statusStore.set('syncing');
+
+  try {
+    if (choice === 'cancel') {
+      if (supabase) await supabase.auth.signOut();
+      pendingConflictStore.set(null);
+      conflictLocalSnapshot = null;
+      statusStore.set('idle');
+      return;
+    }
+
+    if (choice === 'keep-local') {
+      const local = conflictLocalSnapshot ?? get(appState);
+      await clearRemoteState();
+      await pushFullState(local);
+    } else {
+      const pulled = await pullFullState();
+      if (pulled) applyServerState(pulled);
+    }
+
+    pendingConflictStore.set(null);
+    conflictLocalSnapshot = null;
+    markSynced();
+  } catch (err) {
+    recordError(err);
+  }
+}
+
+function schedulePush(state: AppState): void {
+  if (pushTimer) clearTimeout(pushTimer);
+  pushTimer = setTimeout(() => {
+    pushTimer = null;
+    void runPush(state);
+  }, pushDelayMs);
+  statusStore.set('syncing');
+}
+
+async function runPush(state: AppState): Promise<void> {
+  if (!currentSession) return;
+  try {
+    await pushFullState(state);
+    markSynced();
+  } catch (err) {
+    recordError(err);
+  }
+}
+
+function cancelPendingPush(): void {
+  if (pushTimer) {
+    clearTimeout(pushTimer);
+    pushTimer = null;
+  }
+}
+
+function applyServerState(state: AppState): void {
+  suppressNextChange = true;
+  replaceAppState(state);
+}
+
+function isLocallyEmpty(state: AppState): boolean {
+  return state.boxes.length === 0 && state.flavors.length === 0 && state.events.length === 0;
+}
+
+function markSynced(): void {
+  statusStore.set('saved');
+  lastSyncedAtStore.set(new Date());
+  lastErrorStore.set(null);
+}
+
+function recordError(err: unknown): void {
+  const message =
+    err instanceof SyncError ? err.message : err instanceof Error ? err.message : 'Sync error';
+  lastErrorStore.set(message);
+  statusStore.set('error');
+  console.error('Sync error:', err);
+}

--- a/src/lib/sync.ts
+++ b/src/lib/sync.ts
@@ -1,0 +1,279 @@
+/**
+ * Push / pull helpers for the BroteinBuddy sync backend.
+ *
+ * These functions assume a signed-in session; the caller is responsible for
+ * checking auth state first. They translate between the client's `AppState`
+ * shape and the two server tables (`app_states` snapshot + `events`
+ * append-only log).
+ *
+ * Pushes overwrite the snapshot and insert any events the server doesn't
+ * already have (idempotent by event id). Pulls assemble a full `AppState`
+ * from both tables, run it through the schema migration pipeline, and
+ * validate against `isAppState` before returning — same defensive posture
+ * as `loadState()` in `lib/storage.ts`.
+ *
+ * @module lib/sync
+ */
+
+import { supabase } from './supabase';
+import { isAppState, type AppState, createDefaultAppState } from '../types/models';
+import type { AppEvent, AppEventType } from '../types/events';
+import { migrateState } from './storage';
+
+/**
+ * Error raised when a sync operation fails. Wraps the underlying supabase
+ * error so callers (mostly the sync coordinator) can surface a clean
+ * message in the UI.
+ */
+export class SyncError extends Error {
+  readonly cause?: unknown;
+  constructor(message: string, cause?: unknown) {
+    super(message);
+    this.name = 'SyncError';
+    this.cause = cause;
+  }
+}
+
+/**
+ * Lightweight summary of the server-side state for a user. Used by the
+ * sign-in conflict flow to render "the server has X boxes, last change Y"
+ * without pulling the full payload.
+ */
+export interface RemoteStateSummary {
+  exists: boolean;
+  boxCount: number;
+  flavorCount: number;
+  eventCount: number;
+  updatedAt: string | null;
+}
+
+interface AppStateRow {
+  user_id: string;
+  version: number;
+  boxes: unknown;
+  flavors: unknown;
+  favorite_flavor_id: string | null;
+  settings: unknown;
+  updated_at: string;
+}
+
+interface EventRow {
+  id: string;
+  user_id: string;
+  type: string;
+  payload: Record<string, unknown>;
+  event_timestamp: string;
+}
+
+function requireClient() {
+  if (!supabase) {
+    throw new SyncError('Sync is not configured (Supabase env vars missing).');
+  }
+  return supabase;
+}
+
+async function requireUserId(): Promise<string> {
+  const client = requireClient();
+  const { data, error } = await client.auth.getUser();
+  if (error || !data.user) {
+    throw new SyncError('No authenticated user. Sign in before syncing.', error);
+  }
+  return data.user.id;
+}
+
+/**
+ * Reads just enough remote state to decide whether a conflict exists.
+ *
+ * Cheap by design — one row + two counts, no event payloads.
+ */
+export async function peekRemoteState(): Promise<RemoteStateSummary> {
+  const client = requireClient();
+  const userId = await requireUserId();
+
+  const { data: row, error: rowErr } = await client
+    .from('app_states')
+    .select('boxes, flavors, updated_at')
+    .eq('user_id', userId)
+    .maybeSingle();
+
+  if (rowErr) {
+    throw new SyncError('Failed to read remote app_state.', rowErr);
+  }
+
+  if (!row) {
+    return { exists: false, boxCount: 0, flavorCount: 0, eventCount: 0, updatedAt: null };
+  }
+
+  const { count: eventCount, error: countErr } = await client
+    .from('events')
+    .select('id', { count: 'exact', head: true })
+    .eq('user_id', userId);
+
+  if (countErr) {
+    throw new SyncError('Failed to count remote events.', countErr);
+  }
+
+  return {
+    exists: true,
+    boxCount: Array.isArray(row.boxes) ? row.boxes.length : 0,
+    flavorCount: Array.isArray(row.flavors) ? row.flavors.length : 0,
+    eventCount: eventCount ?? 0,
+    updatedAt: row.updated_at,
+  };
+}
+
+/**
+ * Downloads the full server state for the current user and assembles it
+ * into a valid `AppState`.
+ *
+ * Returns `null` when the user has no `app_states` row yet (first ever
+ * sign-in from a brand-new device). The result is run through the schema
+ * migration pipeline so even older server data is upgraded before the
+ * caller sees it.
+ */
+export async function pullFullState(): Promise<AppState | null> {
+  const client = requireClient();
+  const userId = await requireUserId();
+
+  const { data: snapshot, error: snapErr } = await client
+    .from('app_states')
+    .select('user_id, version, boxes, flavors, favorite_flavor_id, settings, updated_at')
+    .eq('user_id', userId)
+    .maybeSingle<AppStateRow>();
+
+  if (snapErr) {
+    throw new SyncError('Failed to read remote app_state.', snapErr);
+  }
+
+  if (!snapshot) return null;
+
+  const { data: eventRows, error: evErr } = await client
+    .from('events')
+    .select('id, user_id, type, payload, event_timestamp')
+    .eq('user_id', userId)
+    .order('event_timestamp', { ascending: true })
+    .returns<EventRow[]>();
+
+  if (evErr) {
+    throw new SyncError('Failed to read remote events.', evErr);
+  }
+
+  const events: unknown[] = (eventRows ?? []).map((row) => ({
+    id: row.id,
+    timestamp: row.event_timestamp,
+    type: row.type,
+    ...row.payload,
+  }));
+
+  const candidate = {
+    version: snapshot.version,
+    boxes: snapshot.boxes,
+    flavors: snapshot.flavors,
+    favoriteFlavorId: snapshot.favorite_flavor_id,
+    settings: snapshot.settings,
+    events,
+  };
+
+  const migrated = migrateState(candidate);
+  if (!isAppState(migrated)) {
+    throw new SyncError('Server returned data that does not match the AppState schema.');
+  }
+  return migrated;
+}
+
+/**
+ * Pushes the full local state up to the server.
+ *
+ * Steps:
+ *   1. Upsert the `app_states` snapshot row (overwrites server snapshot).
+ *   2. Insert every event in `state.events`. The events table's primary
+ *      key is the client-generated event id, so duplicate inserts are
+ *      no-ops — re-pushing the same set is safe.
+ *
+ * The server snapshot wins for boxes/flavors/favorite/settings; events
+ * are union-merged by id. This matches the PR 2 "last-write-wins on the
+ * snapshot, append-only on the timeline" sync semantics.
+ */
+export async function pushFullState(state: AppState): Promise<void> {
+  const client = requireClient();
+  const userId = await requireUserId();
+
+  const { error: upsertErr } = await client.from('app_states').upsert(
+    {
+      user_id: userId,
+      version: state.version,
+      boxes: state.boxes,
+      flavors: state.flavors,
+      favorite_flavor_id: state.favoriteFlavorId,
+      settings: state.settings,
+    },
+    { onConflict: 'user_id' }
+  );
+
+  if (upsertErr) {
+    throw new SyncError('Failed to upsert remote app_state.', upsertErr);
+  }
+
+  if (state.events.length === 0) return;
+
+  const rows = state.events.map((event) => splitEventForRow(event, userId));
+
+  // `ignoreDuplicates: true` translates to ON CONFLICT DO NOTHING — re-pushing
+  // an event with the same id leaves the existing row untouched.
+  const { error: evErr } = await client
+    .from('events')
+    .upsert(rows, { onConflict: 'id', ignoreDuplicates: true });
+
+  if (evErr) {
+    throw new SyncError('Failed to insert remote events.', evErr);
+  }
+}
+
+/**
+ * Wipes ALL server state for the current user (snapshot + every event).
+ *
+ * Used by the "Keep this device" branch of the sign-in conflict modal: we
+ * clear the server, then push the local state fresh.
+ */
+export async function clearRemoteState(): Promise<void> {
+  const client = requireClient();
+  const userId = await requireUserId();
+
+  const { error: evErr } = await client.from('events').delete().eq('user_id', userId);
+  if (evErr) {
+    throw new SyncError('Failed to delete remote events.', evErr);
+  }
+
+  const { error: snapErr } = await client.from('app_states').delete().eq('user_id', userId);
+  if (snapErr) {
+    throw new SyncError('Failed to delete remote app_state.', snapErr);
+  }
+}
+
+/**
+ * Splits an AppEvent into the column shape expected by the `events` table:
+ * shared fields (id, timestamp, type) go to dedicated columns, the rest
+ * becomes the JSONB payload.
+ */
+function splitEventForRow(event: AppEvent, userId: string) {
+  const { id, timestamp, type, ...payload } = event as unknown as {
+    id: string;
+    timestamp: string;
+    type: AppEventType;
+  } & Record<string, unknown>;
+  return {
+    id,
+    user_id: userId,
+    type,
+    payload,
+    event_timestamp: timestamp,
+  };
+}
+
+/**
+ * Builds a fresh "default" remote state. Helper for tests and for the
+ * "first sign-in, server empty" path where we want to start clean.
+ */
+export function emptyServerState(): AppState {
+  return createDefaultAppState();
+}

--- a/src/routes/Inventory.svelte
+++ b/src/routes/Inventory.svelte
@@ -17,6 +17,7 @@
   import Modal from '$lib/components/Modal.svelte';
   import AddInventoryModal from '$lib/components/AddInventoryModal.svelte';
   import BackupRestoreModal from '$lib/components/BackupRestoreModal.svelte';
+  import SyncAccountModal from '$lib/components/SyncAccountModal.svelte';
   import { push } from 'svelte-spa-router';
   import { ROUTES } from '$lib/router/routes';
   import { appState, addFlavor } from '$lib/stores';
@@ -36,6 +37,11 @@
    * Modal state for backup/restore
    */
   let isBackupModalOpen = $state(false);
+
+  /**
+   * Modal state for sync & account
+   */
+  let isSyncModalOpen = $state(false);
 
   /**
    * View mode state
@@ -186,6 +192,14 @@
       >
         Backup
       </Button>
+      <Button
+        variant="ghost"
+        size="base"
+        onclick={() => (isSyncModalOpen = true)}
+        testId="inventory-sync-button"
+      >
+        Sync
+      </Button>
     </div>
   </header>
 
@@ -331,6 +345,9 @@
 
 <!-- Backup & Restore Modal -->
 <BackupRestoreModal open={isBackupModalOpen} onclose={() => (isBackupModalOpen = false)} />
+
+<!-- Sync & Account Modal -->
+<SyncAccountModal open={isSyncModalOpen} onclose={() => (isSyncModalOpen = false)} />
 
 <!-- New Flavor Modal -->
 <Modal open={isNewFlavorModalOpen} title="Add New Flavor" onclose={closeNewFlavorModal} size="sm">

--- a/supabase/README.md
+++ b/supabase/README.md
@@ -1,0 +1,78 @@
+# Supabase setup for BroteinBuddy
+
+This directory holds the Supabase project configuration and SQL migrations
+for the multi-device sync backend introduced in PR 2.
+
+## One-time setup
+
+1. **Install the Supabase CLI:**
+
+   ```bash
+   brew install supabase/tap/supabase
+   ```
+
+2. **Create the remote project** at <https://supabase.com> (free tier is fine).
+   Copy the project ref from the URL (`https://supabase.com/dashboard/project/<ref>`).
+
+3. **Log in and link this repo to your project:**
+
+   ```bash
+   supabase login
+   supabase link --project-ref <your-ref>
+   ```
+
+4. **Apply migrations:**
+
+   ```bash
+   supabase db push
+   ```
+
+   This runs every `.sql` file under `migrations/` against the remote project
+   in timestamp order. Re-running `db push` is safe — already-applied
+   migrations are skipped.
+
+5. **Configure auth redirect URLs** in the Supabase dashboard
+   (`Authentication → URL Configuration`):
+   - Site URL: `https://brotein-buddy.vercel.app`
+   - Redirect URLs:
+     - `https://brotein-buddy.vercel.app`
+     - `http://localhost:5173` (for `npm run dev`)
+     - Any Vercel preview URL pattern if you want magic links from PR previews
+
+6. **Copy the project URL and `anon` key** from
+   `Project Settings → API` and add them to:
+   - `.env.local` for local dev (file is git-ignored)
+   - Vercel project env vars: `VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`
+
+## Local development against a Dockerised Supabase
+
+If you have Docker running, `supabase start` spins up a full local stack
+(Postgres + Auth + Studio) so you don't need the remote project for
+development:
+
+```bash
+supabase start
+# Studio:    http://localhost:54323
+# API URL:   http://localhost:54321
+# anon key:  printed by `supabase status`
+```
+
+Put the local URL + anon key in `.env.local` and the app will hit your
+machine instead of the remote.
+
+## Schema overview
+
+Two tables, both protected by row-level security so a signed-in user can
+only access their own rows:
+
+- **`app_states`** — one row per user. Holds the boxes/flavors/favorite/
+  settings/version snapshot. Overwritten on every client push.
+- **`events`** — append-only timeline. Primary key is the
+  client-generated `ev_<uuid>` so re-pushing the same event is idempotent.
+
+The split mirrors the client layout (snapshot in `AppState`, append-only
+log in `AppState.events`) and positions PR 3 to subscribe to the `events`
+table in realtime.
+
+See `docs/adr/012-supabase-sync.md` for the rationale and
+`docs/teaching/1.7-supabase-magic-link-sync.md` for a deeper walkthrough.

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,63 @@
+# Supabase project configuration.
+#
+# This file is consumed by the Supabase CLI (`supabase` command). Install
+# the CLI with `brew install supabase/tap/supabase`, then:
+#
+#   supabase login                       # one-time
+#   supabase link --project-ref <ref>    # link this repo to your project
+#   supabase db push                     # apply migrations/ to the linked project
+#
+# The `project_id` below names the local project (used for `supabase start`
+# to run a local Postgres/Auth stack against Docker). It is NOT the remote
+# project ref.
+
+project_id = "brotein-buddy"
+
+[api]
+enabled = true
+port = 54321
+schemas = ["public"]
+extra_search_path = ["public"]
+max_rows = 1000
+
+[db]
+port = 54322
+shadow_port = 54320
+major_version = 17
+
+[studio]
+enabled = true
+port = 54323
+
+[auth]
+enabled = true
+# Public URL of the app. The magic-link email contains a redirect that lands
+# here; supabase-js then completes the session client-side.
+site_url = "http://localhost:5173"
+additional_redirect_urls = ["https://brotein-buddy.vercel.app"]
+jwt_expiry = 3600
+enable_signup = true
+enable_anonymous_sign_ins = false
+
+[auth.email]
+enable_signup = true
+enable_confirmations = false
+double_confirm_changes = true
+secure_password_change = false
+# Magic-link is the only sign-in method we use; password sign-in stays off.
+
+[auth.sms]
+enable_signup = false
+enable_confirmations = false
+
+[storage]
+enabled = false
+
+[edge_runtime]
+enabled = false
+
+[analytics]
+enabled = false
+
+[functions]
+enabled = false

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,63 +1,408 @@
-# Supabase project configuration.
-#
-# This file is consumed by the Supabase CLI (`supabase` command). Install
-# the CLI with `brew install supabase/tap/supabase`, then:
-#
-#   supabase login                       # one-time
-#   supabase link --project-ref <ref>    # link this repo to your project
-#   supabase db push                     # apply migrations/ to the linked project
-#
-# The `project_id` below names the local project (used for `supabase start`
-# to run a local Postgres/Auth stack against Docker). It is NOT the remote
-# project ref.
-
+# For detailed configuration reference documentation, visit:
+# https://supabase.com/docs/guides/local-development/cli/config
+# A string used to distinguish different Supabase projects on the same host. Defaults to the
+# working directory name when running `supabase init`.
 project_id = "brotein-buddy"
 
 [api]
 enabled = true
+# Port to use for the API URL.
 port = 54321
-schemas = ["public"]
-extra_search_path = ["public"]
+# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# endpoints. `public` and `graphql_public` schemas are included by default.
+schemas = ["public", "graphql_public"]
+# Extra schemas to add to the search_path of every request.
+extra_search_path = ["public", "extensions"]
+# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# for accidental or malicious requests.
 max_rows = 1000
 
+[api.tls]
+# Enable HTTPS endpoints locally using a self-signed certificate.
+enabled = false
+# Paths to self-signed certificate pair.
+# cert_path = "../certs/my-cert.pem"
+# key_path = "../certs/my-key.pem"
+
 [db]
+# Port to use for the local database URL.
 port = 54322
+# Port used by db diff command to initialize the shadow database.
 shadow_port = 54320
+# Maximum amount of time to wait for health check when starting the local database.
+health_timeout = "2m"
+# The database major version to use. This has to be the same as your remote database's. Run `SHOW
+# server_version;` on the remote database to check.
 major_version = 17
+
+[db.pooler]
+enabled = false
+# Port to use for the local connection pooler.
+port = 54329
+# Specifies when a server connection can be reused by other clients.
+# Configure one of the supported pooler modes: `transaction`, `session`.
+pool_mode = "transaction"
+# How many server connections to allow per user/database pair.
+default_pool_size = 20
+# Maximum number of client connections allowed.
+max_client_conn = 100
+
+# [db.vault]
+# secret_key = "env(SECRET_VALUE)"
+
+[db.migrations]
+# If disabled, migrations will be skipped during a db push or reset.
+enabled = true
+# Specifies an ordered list of schema files that describe your database.
+# Supports glob patterns relative to supabase directory: "./schemas/*.sql"
+schema_paths = []
+
+[db.seed]
+# If enabled, seeds the database after migrations during a db reset.
+enabled = true
+# Specifies an ordered list of seed files to load during db reset.
+# Supports glob patterns relative to supabase directory: "./seeds/*.sql"
+sql_paths = ["./seed.sql"]
+
+[db.network_restrictions]
+# Enable management of network restrictions.
+enabled = false
+# List of IPv4 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv4 connections. Set empty array to block all IPs.
+allowed_cidrs = ["0.0.0.0/0"]
+# List of IPv6 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv6 connections. Set empty array to block all IPs.
+allowed_cidrs_v6 = ["::/0"]
+
+# Uncomment to reject non-secure connections to the database.
+# [db.ssl_enforcement]
+# enabled = true
+
+[realtime]
+enabled = true
+# Bind realtime via either IPv4 or IPv6. (default: IPv4)
+# ip_version = "IPv6"
+# The maximum length in bytes of HTTP request headers. (default: 4096)
+# max_header_length = 4096
 
 [studio]
 enabled = true
+# Port to use for Supabase Studio.
 port = 54323
+# External URL of the API server that frontend connects to.
+api_url = "http://127.0.0.1"
+# OpenAI API Key to use for Supabase AI in the Supabase Studio.
+openai_api_key = "env(OPENAI_API_KEY)"
+
+# Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
+# are monitored, and you can view the emails that would have been sent from the web interface.
+[inbucket]
+enabled = true
+# Port to use for the email testing server web interface.
+port = 54324
+# Uncomment to expose additional ports for testing user applications that send emails.
+# smtp_port = 54325
+# pop3_port = 54326
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+[storage]
+enabled = true
+# The maximum file size allowed (e.g. "5MB", "500KB").
+file_size_limit = "50MiB"
+
+# Uncomment to configure local storage buckets
+# [storage.buckets.images]
+# public = false
+# file_size_limit = "50MiB"
+# allowed_mime_types = ["image/png", "image/jpeg"]
+# objects_path = "./images"
+
+# Allow connections via S3 compatible clients
+[storage.s3_protocol]
+enabled = true
+
+# Image transformation API is available to Supabase Pro plan.
+# [storage.image_transformation]
+# enabled = true
+
+# Store analytical data in S3 for running ETL jobs over Iceberg Catalog
+# This feature is only available on the hosted platform.
+[storage.analytics]
+enabled = false
+max_namespaces = 5
+max_tables = 10
+max_catalogs = 2
+
+# Analytics Buckets is available to Supabase Pro plan.
+# [storage.analytics.buckets.my-warehouse]
+
+# Store vector embeddings in S3 for large and durable datasets
+# This feature is only available on the hosted platform.
+[storage.vector]
+enabled = false
+max_buckets = 10
+max_indexes = 5
+
+# Vector Buckets is available to Supabase Pro plan.
+# [storage.vector.buckets.documents-openai]
 
 [auth]
 enabled = true
-# Public URL of the app. The magic-link email contains a redirect that lands
-# here; supabase-js then completes the session client-side.
+# The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
+# in emails.
 site_url = "http://localhost:5173"
+# The public URL that Auth serves on. Defaults to the API external URL with `/auth/v1` appended.
+# external_url = ""
+# A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
 additional_redirect_urls = ["https://brotein-buddy.vercel.app"]
+# How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
 jwt_expiry = 3600
+# JWT issuer URL. If not set, defaults to auth.external_url.
+# jwt_issuer = ""
+# Path to JWT signing key. DO NOT commit your signing keys file to git.
+# signing_keys_path = "./signing_keys.json"
+# If disabled, the refresh token will never expire.
+enable_refresh_token_rotation = true
+# Allows refresh tokens to be reused after expiry, up to the specified interval in seconds.
+# Requires enable_refresh_token_rotation = true.
+refresh_token_reuse_interval = 10
+# Allow/disallow new user signups to your project.
 enable_signup = true
+# Allow/disallow anonymous sign-ins to your project.
 enable_anonymous_sign_ins = false
+# Allow/disallow testing manual linking of accounts
+enable_manual_linking = false
+# Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.
+minimum_password_length = 6
+# Passwords that do not meet the following requirements will be rejected as weak. Supported values
+# are: `letters_digits`, `lower_upper_letters_digits`, `lower_upper_letters_digits_symbols`
+password_requirements = ""
+
+# Configure passkey sign-ins.
+# [auth.passkey]
+# enabled = false
+
+# Configure WebAuthn relying party settings (required when passkey is enabled).
+# [auth.webauthn]
+# rp_display_name = "Supabase"
+# rp_id = "localhost"
+# rp_origins = ["http://127.0.0.1:3000"]
+
+[auth.rate_limit]
+# Number of emails that can be sent per hour. Requires auth.email.smtp to be enabled.
+email_sent = 2
+# Number of SMS messages that can be sent per hour. Requires auth.sms to be enabled.
+sms_sent = 30
+# Number of anonymous sign-ins that can be made per hour per IP address. Requires enable_anonymous_sign_ins = true.
+anonymous_users = 30
+# Number of sessions that can be refreshed in a 5 minute interval per IP address.
+token_refresh = 150
+# Number of sign up and sign-in requests that can be made in a 5 minute interval per IP address (excludes anonymous users).
+sign_in_sign_ups = 30
+# Number of OTP / Magic link verifications that can be made in a 5 minute interval per IP address.
+token_verifications = 30
+# Number of Web3 logins that can be made in a 5 minute interval per IP address.
+web3 = 30
+
+# Configure one of the supported captcha providers: `hcaptcha`, `turnstile`.
+# [auth.captcha]
+# enabled = true
+# provider = "hcaptcha"
+# secret = ""
 
 [auth.email]
+# Allow/disallow new user signups via email to your project.
 enable_signup = true
-enable_confirmations = false
+# If enabled, a user will be required to confirm any email change on both the old, and new email
+# addresses. If disabled, only the new email is required to confirm.
 double_confirm_changes = true
+# If enabled, users need to confirm their email address before signing in.
+enable_confirmations = false
+# If enabled, users will need to reauthenticate or have logged in recently to change their password.
 secure_password_change = false
-# Magic-link is the only sign-in method we use; password sign-in stays off.
+# Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
+max_frequency = "1s"
+# Number of characters used in the email OTP.
+otp_length = 6
+# Number of seconds before the email OTP expires (defaults to 1 hour).
+otp_expiry = 3600
+
+# Use a production-ready SMTP server
+# [auth.email.smtp]
+# enabled = true
+# host = "smtp.sendgrid.net"
+# port = 587
+# user = "apikey"
+# pass = "env(SENDGRID_API_KEY)"
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+# Uncomment to customize email template
+# [auth.email.template.invite]
+# subject = "You have been invited"
+# content_path = "./supabase/templates/invite.html"
+
+# Uncomment to customize notification email template
+# [auth.email.notification.password_changed]
+# enabled = true
+# subject = "Your password has been changed"
+# content_path = "./templates/password_changed_notification.html"
 
 [auth.sms]
+# Allow/disallow new user signups via SMS to your project.
 enable_signup = false
+# If enabled, users need to confirm their phone number before signing in.
 enable_confirmations = false
+# Template for sending OTP to users
+template = "Your code is {{ .Code }}"
+# Controls the minimum amount of time that must pass before sending another sms otp.
+max_frequency = "5s"
 
-[storage]
+# Use pre-defined map of phone number to OTP for testing.
+# [auth.sms.test_otp]
+# 4152127777 = "123456"
+
+# Configure logged in session timeouts.
+# [auth.sessions]
+# Force log out after the specified duration.
+# timebox = "24h"
+# Force log out if the user has been inactive longer than the specified duration.
+# inactivity_timeout = "8h"
+
+# This hook runs before a new user is created and allows developers to reject the request based on the incoming user object.
+# [auth.hook.before_user_created]
+# enabled = true
+# uri = "pg-functions://postgres/auth/before-user-created-hook"
+
+# This hook runs before a token is issued and allows you to add additional claims based on the authentication method used.
+# [auth.hook.custom_access_token]
+# enabled = true
+# uri = "pg-functions://<database>/<schema>/<hook_name>"
+
+# Configure one of the supported SMS providers: `twilio`, `twilio_verify`, `messagebird`, `textlocal`, `vonage`.
+[auth.sms.twilio]
 enabled = false
+account_sid = ""
+message_service_sid = ""
+# DO NOT commit your Twilio auth token to git. Use environment variable substitution instead:
+auth_token = "env(SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN)"
+
+# Multi-factor-authentication is available to Supabase Pro plan.
+[auth.mfa]
+# Control how many MFA factors can be enrolled at once per user.
+max_enrolled_factors = 10
+
+# Control MFA via App Authenticator (TOTP)
+[auth.mfa.totp]
+enroll_enabled = false
+verify_enabled = false
+
+# Configure MFA via Phone Messaging
+[auth.mfa.phone]
+enroll_enabled = false
+verify_enabled = false
+otp_length = 6
+template = "Your code is {{ .Code }}"
+max_frequency = "5s"
+
+# Configure MFA via WebAuthn
+# [auth.mfa.web_authn]
+# enroll_enabled = true
+# verify_enabled = true
+
+# Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
+# `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin_oidc`, `notion`, `twitch`,
+# `twitter`, `x`, `slack`, `spotify`, `workos`, `zoom`.
+[auth.external.apple]
+enabled = false
+client_id = ""
+# DO NOT commit your OAuth provider secret to git. Use environment variable substitution instead:
+secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
+# Overrides the default auth callback URL derived from auth.external_url.
+redirect_uri = ""
+# Overrides the default auth provider URL. Used to support self-hosted gitlab, single-tenant Azure,
+# or any other third-party OIDC providers.
+url = ""
+# If enabled, the nonce check will be skipped. Required for local sign in with Google auth.
+skip_nonce_check = false
+# If enabled, it will allow the user to successfully authenticate when the provider does not return an email address.
+email_optional = false
+
+# Allow Solana wallet holders to sign in to your project via the Sign in with Solana (SIWS, EIP-4361) standard.
+# You can configure "web3" rate limit in the [auth.rate_limit] section and set up [auth.captcha] if self-hosting.
+[auth.web3.solana]
+enabled = false
+
+# Use Firebase Auth as a third-party provider alongside Supabase Auth.
+[auth.third_party.firebase]
+enabled = false
+# project_id = "my-firebase-project"
+
+# Use Auth0 as a third-party provider alongside Supabase Auth.
+[auth.third_party.auth0]
+enabled = false
+# tenant = "my-auth0-tenant"
+# tenant_region = "us"
+
+# Use AWS Cognito (Amplify) as a third-party provider alongside Supabase Auth.
+[auth.third_party.aws_cognito]
+enabled = false
+# user_pool_id = "my-user-pool-id"
+# user_pool_region = "us-east-1"
+
+# Use Clerk as a third-party provider alongside Supabase Auth.
+[auth.third_party.clerk]
+enabled = false
+# Obtain from https://clerk.com/setup/supabase
+# domain = "example.clerk.accounts.dev"
+
+# OAuth server configuration
+[auth.oauth_server]
+# Enable OAuth server functionality
+enabled = false
+# Path for OAuth consent flow UI
+authorization_url_path = "/oauth/consent"
+# Allow dynamic client registration
+allow_dynamic_registration = false
 
 [edge_runtime]
-enabled = false
+enabled = true
+# Supported request policies: `oneshot`, `per_worker`.
+# `per_worker` (default) — enables hot reload during local development.
+# `oneshot` — fallback mode if hot reload causes issues (e.g. in large repos or with symlinks).
+policy = "per_worker"
+# Port to attach the Chrome inspector for debugging edge functions.
+inspector_port = 8083
+# The Deno major version to use.
+deno_version = 2
+
+# [edge_runtime.secrets]
+# secret_key = "env(SECRET_VALUE)"
 
 [analytics]
-enabled = false
+enabled = true
+port = 54327
+# Configure one of the supported backends: `postgres`, `bigquery`.
+backend = "postgres"
 
-[functions]
-enabled = false
+# Experimental features may be deprecated any time
+[experimental]
+# Configures Postgres storage engine to use OrioleDB (S3)
+orioledb_version = ""
+# Configures S3 bucket URL, eg. <bucket_name>.s3-<region>.amazonaws.com
+s3_host = "env(S3_HOST)"
+# Configures S3 bucket region, eg. us-east-1
+s3_region = "env(S3_REGION)"
+# Configures AWS_ACCESS_KEY_ID for S3 bucket
+s3_access_key = "env(S3_ACCESS_KEY)"
+# Configures AWS_SECRET_ACCESS_KEY for S3 bucket
+s3_secret_key = "env(S3_SECRET_KEY)"
+
+# [experimental.pgdelta]
+# When enabled, pg-delta becomes the active engine for supported schema flows.
+# enabled = false
+# Directory under `supabase/` where declarative files are written.
+# declarative_schema_path = "./database"
+# JSON string passed through to pg-delta SQL formatting.
+# format_options = "{\"keywordCase\":\"upper\",\"indent\":2,\"maxWidth\":80,\"commaStyle\":\"trailing\"}"

--- a/supabase/migrations/20260514000000_initial_app_state_and_events.sql
+++ b/supabase/migrations/20260514000000_initial_app_state_and_events.sql
@@ -1,0 +1,103 @@
+-- Initial schema for BroteinBuddy multi-device sync (PR 2).
+--
+-- Splits AppState into two tables on the server, mirroring the client layout
+-- in src/types/models.ts and src/types/events.ts:
+--
+--   app_states  - one row per user, holding the snapshot (boxes, flavors,
+--                 favorite, settings, version). Overwritten on every push.
+--   events      - append-only timeline, keyed by the client-generated event
+--                 id so re-pushing the same event is a no-op (idempotent).
+--
+-- Both tables are protected by row-level security: a signed-in user can read
+-- and write only their own rows. The anon key (shipped in the client bundle)
+-- gains nothing without a valid JWT.
+
+----------------------------------------------------------------------
+-- app_states: snapshot table (one row per user)
+----------------------------------------------------------------------
+
+create table public.app_states (
+  user_id uuid primary key references auth.users (id) on delete cascade,
+  version integer not null default 3,
+  boxes jsonb not null default '[]'::jsonb,
+  flavors jsonb not null default '[]'::jsonb,
+  favorite_flavor_id text,
+  settings jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+comment on table public.app_states is
+  'BroteinBuddy snapshot per user. Mirrors AppState minus events[] (which lives in public.events).';
+
+-- updated_at is bumped by a trigger so clients don''t have to set it.
+create or replace function public.set_app_states_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+create trigger app_states_set_updated_at
+before update on public.app_states
+for each row execute function public.set_app_states_updated_at();
+
+----------------------------------------------------------------------
+-- events: append-only timeline (one row per AppEvent)
+----------------------------------------------------------------------
+
+create table public.events (
+  -- The client-generated `ev_<uuid>` id. Using it as the primary key makes
+  -- re-pushing the same event idempotent: ON CONFLICT DO NOTHING on insert.
+  id text primary key,
+  user_id uuid not null references auth.users (id) on delete cascade,
+  type text not null,
+  payload jsonb not null,
+  event_timestamp timestamptz not null,
+  inserted_at timestamptz not null default now()
+);
+
+comment on table public.events is
+  'BroteinBuddy timeline. One row per AppEvent. Primary key is the client id so re-pushes are no-ops.';
+
+create index events_user_id_timestamp_idx
+  on public.events (user_id, event_timestamp);
+
+----------------------------------------------------------------------
+-- Row Level Security
+----------------------------------------------------------------------
+
+alter table public.app_states enable row level security;
+alter table public.events     enable row level security;
+
+create policy "app_states owner select"
+  on public.app_states for select
+  using (auth.uid() = user_id);
+
+create policy "app_states owner insert"
+  on public.app_states for insert
+  with check (auth.uid() = user_id);
+
+create policy "app_states owner update"
+  on public.app_states for update
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+create policy "app_states owner delete"
+  on public.app_states for delete
+  using (auth.uid() = user_id);
+
+create policy "events owner select"
+  on public.events for select
+  using (auth.uid() = user_id);
+
+create policy "events owner insert"
+  on public.events for insert
+  with check (auth.uid() = user_id);
+
+-- No update/delete policy on events: the timeline is append-only on the
+-- server. Clients that want to remove rows must do it through a future
+-- admin path (PR 3 may revisit if compaction is needed).

--- a/tests/unit/auth.test.ts
+++ b/tests/unit/auth.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Unit tests for the auth module.
+ *
+ * Mocks the supabase client. Verifies sendMagicLink/signOut error handling
+ * and the session-store reflection of supabase auth events.
+ */
+
+import { describe, it, expect, beforeEach, vi, type Mock } from 'vitest';
+import { get } from 'svelte/store';
+
+interface MockAuth {
+  getSession: Mock;
+  onAuthStateChange: Mock;
+  signInWithOtp: Mock;
+  signOut: Mock;
+}
+
+let mockAuth: MockAuth;
+let authChangeHandler: ((event: string, session: unknown) => void) | null = null;
+
+function buildMockAuth(): MockAuth {
+  return {
+    getSession: vi.fn(async () => ({ data: { session: null } })),
+    onAuthStateChange: vi.fn((handler: (event: string, session: unknown) => void) => {
+      authChangeHandler = handler;
+      return { data: { subscription: { unsubscribe: vi.fn() } } };
+    }),
+    signInWithOtp: vi.fn(async () => ({ error: null })),
+    signOut: vi.fn(async () => ({ error: null })),
+  };
+}
+
+vi.mock('../../src/lib/supabase', () => ({
+  get supabase() {
+    return { auth: mockAuth };
+  },
+  isSyncConfigured: () => true,
+}));
+
+mockAuth = buildMockAuth();
+
+// window.location.origin used inside sendMagicLink — jsdom provides it.
+const { sendMagicLink, signOut, session, AuthError, SyncNotConfiguredError } =
+  await import('../../src/lib/auth');
+
+beforeEach(() => {
+  mockAuth.signInWithOtp.mockClear();
+  mockAuth.signOut.mockClear();
+  mockAuth.getSession.mockClear();
+});
+
+describe('sendMagicLink', () => {
+  it('calls supabase.auth.signInWithOtp with the trimmed email', async () => {
+    await sendMagicLink('  user@example.com  ');
+    expect(mockAuth.signInWithOtp).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: 'user@example.com',
+        options: expect.objectContaining({
+          emailRedirectTo: expect.any(String),
+          shouldCreateUser: true,
+        }),
+      })
+    );
+  });
+
+  it('throws AuthError on empty email', async () => {
+    await expect(sendMagicLink('   ')).rejects.toBeInstanceOf(AuthError);
+  });
+
+  it('throws AuthError when supabase returns an error', async () => {
+    mockAuth.signInWithOtp.mockResolvedValueOnce({ error: { message: 'rate limit' } });
+    await expect(sendMagicLink('user@example.com')).rejects.toMatchObject({
+      name: 'AuthError',
+      message: 'rate limit',
+    });
+  });
+});
+
+describe('signOut', () => {
+  it('calls supabase.auth.signOut', async () => {
+    await signOut();
+    expect(mockAuth.signOut).toHaveBeenCalled();
+  });
+
+  it('throws AuthError when supabase returns an error', async () => {
+    mockAuth.signOut.mockResolvedValueOnce({ error: { message: 'network down' } });
+    await expect(signOut()).rejects.toBeInstanceOf(AuthError);
+  });
+});
+
+describe('session store', () => {
+  it('starts at null and reflects auth-state-change updates', () => {
+    expect(get(session)).toBeNull();
+    expect(authChangeHandler).not.toBeNull();
+
+    const fakeSession = { user: { id: 'u1', email: 'u1@example.com' } };
+    authChangeHandler!('SIGNED_IN', fakeSession);
+    expect(get(session)).toEqual(fakeSession);
+
+    authChangeHandler!('SIGNED_OUT', null);
+    expect(get(session)).toBeNull();
+  });
+});
+
+describe('SyncNotConfiguredError', () => {
+  // Reset to a state where the supabase singleton is null
+  it('is the class name used when sync is not configured', () => {
+    const err = new SyncNotConfiguredError();
+    expect(err.name).toBe('SyncNotConfiguredError');
+  });
+});

--- a/tests/unit/sync-coordinator.test.ts
+++ b/tests/unit/sync-coordinator.test.ts
@@ -249,6 +249,52 @@ describe('resolveConflict', () => {
   });
 });
 
+describe('auth event serialization', () => {
+  it('processes INITIAL_SESSION before SIGNED_IN even when fired back-to-back', async () => {
+    // Order: INITIAL_SESSION pull completes BEFORE SIGNED_IN reconcile starts.
+    const orderLog: string[] = [];
+
+    let releasePull: () => void = () => {};
+    pullFullState.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          orderLog.push('initial-pull-start');
+          releasePull = () => {
+            orderLog.push('initial-pull-end');
+            resolve(populatedLocalState());
+          };
+        })
+    );
+
+    peekRemoteState.mockImplementationOnce(async () => {
+      orderLog.push('signed-in-peek');
+      return {
+        exists: false,
+        boxCount: 0,
+        flavorCount: 0,
+        eventCount: 0,
+        updatedAt: null,
+      };
+    });
+
+    // Fire both handlers back-to-back, synchronously, before either resolves.
+    authChangeHandler!('INITIAL_SESSION', { user: { id: 'u1' } });
+    authChangeHandler!('SIGNED_IN', { user: { id: 'u1' } });
+
+    // Let INITIAL_SESSION's pull start, then release it.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(orderLog).toEqual(['initial-pull-start']);
+
+    releasePull();
+
+    // Drain.
+    for (let i = 0; i < 10; i++) await Promise.resolve();
+
+    expect(orderLog).toEqual(['initial-pull-start', 'initial-pull-end', 'signed-in-peek']);
+  });
+});
+
 describe('debounced push', () => {
   it('does not push when no session is active', async () => {
     appStateStore.update((state) => ({ ...state, favoriteFlavorId: 'f1' }));

--- a/tests/unit/sync-coordinator.test.ts
+++ b/tests/unit/sync-coordinator.test.ts
@@ -1,0 +1,277 @@
+/**
+ * Unit tests for the sync coordinator.
+ *
+ * Mocks the supabase client and the inner sync module so this test focuses
+ * on the state machine: which auth event triggers which push/pull, the
+ * conflict-pending pathway, debounced push behaviour, and the suppress-
+ * outbound flag during server-driven state replacement.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { get, writable, type Writable } from 'svelte/store';
+import type { AppState } from '../../src/types/models';
+
+let authChangeHandler: ((event: string, session: unknown) => void) | null = null;
+let appStateStore: Writable<AppState>;
+
+const pushFullState = vi.fn(async () => undefined);
+const pullFullState = vi.fn(async () => null as AppState | null);
+const peekRemoteState = vi.fn(async () => ({
+  exists: false,
+  boxCount: 0,
+  flavorCount: 0,
+  eventCount: 0,
+  updatedAt: null,
+}));
+const clearRemoteState = vi.fn(async () => undefined);
+
+class FakeSyncError extends Error {
+  readonly cause?: unknown;
+  constructor(message: string, cause?: unknown) {
+    super(message);
+    this.name = 'SyncError';
+    this.cause = cause;
+  }
+}
+
+const supabaseAuthMock = {
+  onAuthStateChange: vi.fn((handler: (event: string, session: unknown) => void) => {
+    authChangeHandler = handler;
+    return { data: { subscription: { unsubscribe: vi.fn() } } };
+  }),
+  signOut: vi.fn(async () => ({ error: null })),
+};
+
+vi.mock('../../src/lib/supabase', () => ({
+  get supabase() {
+    return { auth: supabaseAuthMock };
+  },
+  isSyncConfigured: () => true,
+}));
+
+vi.mock('../../src/lib/sync', () => ({
+  pushFullState: (...args: unknown[]) => pushFullState(...(args as [])),
+  pullFullState: (...args: unknown[]) => pullFullState(...(args as [])),
+  peekRemoteState: (...args: unknown[]) => peekRemoteState(...(args as [])),
+  clearRemoteState: (...args: unknown[]) => clearRemoteState(...(args as [])),
+  SyncError: FakeSyncError,
+}));
+
+vi.mock('../../src/lib/stores', () => ({
+  get appState() {
+    return appStateStore;
+  },
+  replaceAppState: (state: AppState) => appStateStore.set(state),
+}));
+
+const { createDefaultAppState } = await import('../../src/types/models');
+
+function freshLocalState(): AppState {
+  return createDefaultAppState();
+}
+
+function populatedLocalState(): AppState {
+  return {
+    ...createDefaultAppState(),
+    boxes: [
+      {
+        id: 'b1',
+        flavorId: 'f1',
+        quantity: 5,
+        location: { stack: 0, height: 0 },
+        isOpen: false,
+      },
+    ],
+    flavors: [{ id: 'f1', name: 'Chocolate', randomPool: 'caffeinated' }],
+  };
+}
+
+let coordinator: typeof import('../../src/lib/sync-coordinator');
+
+beforeEach(async () => {
+  vi.resetModules();
+  authChangeHandler = null;
+  appStateStore = writable<AppState>(freshLocalState());
+  pushFullState.mockClear();
+  pullFullState.mockClear();
+  peekRemoteState.mockClear();
+  clearRemoteState.mockClear();
+  supabaseAuthMock.signOut.mockClear();
+  supabaseAuthMock.onAuthStateChange.mockClear();
+
+  coordinator = await import('../../src/lib/sync-coordinator');
+  coordinator.initializeSync();
+  coordinator.setPushDelay(50);
+});
+
+async function fireAuthEvent(event: string, session: unknown = { user: { id: 'u1' } }) {
+  expect(authChangeHandler).not.toBeNull();
+  authChangeHandler!(event, session);
+  // Let the promise chain inside the handler resolve.
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('initializeSync', () => {
+  it('is idempotent', () => {
+    coordinator.initializeSync();
+    coordinator.initializeSync();
+    expect(supabaseAuthMock.onAuthStateChange).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('SIGNED_OUT', () => {
+  it('clears pending conflict and returns status to idle', async () => {
+    await fireAuthEvent('SIGNED_OUT', null);
+    expect(get(coordinator.syncStatus)).toBe('idle');
+    expect(get(coordinator.pendingConflict)).toBeNull();
+  });
+});
+
+describe('SIGNED_IN', () => {
+  it('pushes when the server is empty and the local has data', async () => {
+    appStateStore.set(populatedLocalState());
+    peekRemoteState.mockResolvedValueOnce({
+      exists: false,
+      boxCount: 0,
+      flavorCount: 0,
+      eventCount: 0,
+      updatedAt: null,
+    });
+
+    await fireAuthEvent('SIGNED_IN');
+
+    expect(pushFullState).toHaveBeenCalled();
+    expect(pullFullState).not.toHaveBeenCalled();
+    expect(get(coordinator.syncStatus)).toBe('saved');
+  });
+
+  it('pulls when the server has data and the local is empty', async () => {
+    const server = populatedLocalState();
+    peekRemoteState.mockResolvedValueOnce({
+      exists: true,
+      boxCount: 1,
+      flavorCount: 1,
+      eventCount: 0,
+      updatedAt: '2026-05-14T12:00:00.000Z',
+    });
+    pullFullState.mockResolvedValueOnce(server);
+
+    await fireAuthEvent('SIGNED_IN');
+
+    expect(pullFullState).toHaveBeenCalled();
+    expect(pushFullState).not.toHaveBeenCalled();
+    expect(get(appStateStore).boxes).toHaveLength(1);
+    expect(get(coordinator.syncStatus)).toBe('saved');
+  });
+
+  it('surfaces a pending conflict when both sides have data', async () => {
+    appStateStore.set(populatedLocalState());
+    const summary = {
+      exists: true,
+      boxCount: 4,
+      flavorCount: 2,
+      eventCount: 12,
+      updatedAt: '2026-05-13T08:00:00.000Z',
+    };
+    peekRemoteState.mockResolvedValueOnce(summary);
+
+    await fireAuthEvent('SIGNED_IN');
+
+    expect(get(coordinator.syncStatus)).toBe('conflict-pending');
+    expect(get(coordinator.pendingConflict)).toEqual(summary);
+    expect(pullFullState).not.toHaveBeenCalled();
+    expect(pushFullState).not.toHaveBeenCalled();
+  });
+
+  it('records an error when peek throws', async () => {
+    peekRemoteState.mockRejectedValueOnce(new FakeSyncError('boom'));
+    await fireAuthEvent('SIGNED_IN');
+    expect(get(coordinator.syncStatus)).toBe('error');
+    expect(get(coordinator.lastError)).toBe('boom');
+  });
+});
+
+describe('INITIAL_SESSION', () => {
+  it('silently pulls when a session is hydrated from cache', async () => {
+    pullFullState.mockResolvedValueOnce(populatedLocalState());
+    await fireAuthEvent('INITIAL_SESSION');
+    expect(pullFullState).toHaveBeenCalled();
+    expect(peekRemoteState).not.toHaveBeenCalled();
+    expect(get(coordinator.syncStatus)).toBe('saved');
+  });
+
+  it('does nothing when the hydrated session is null', async () => {
+    await fireAuthEvent('INITIAL_SESSION', null);
+    expect(pullFullState).not.toHaveBeenCalled();
+  });
+});
+
+describe('resolveConflict', () => {
+  beforeEach(async () => {
+    appStateStore.set(populatedLocalState());
+    peekRemoteState.mockResolvedValueOnce({
+      exists: true,
+      boxCount: 4,
+      flavorCount: 2,
+      eventCount: 12,
+      updatedAt: '2026-05-13T08:00:00.000Z',
+    });
+    await fireAuthEvent('SIGNED_IN');
+    expect(get(coordinator.pendingConflict)).not.toBeNull();
+  });
+
+  it('keep-local clears the server then pushes', async () => {
+    await coordinator.resolveConflict('keep-local');
+    expect(clearRemoteState).toHaveBeenCalled();
+    expect(pushFullState).toHaveBeenCalled();
+    expect(get(coordinator.pendingConflict)).toBeNull();
+    expect(get(coordinator.syncStatus)).toBe('saved');
+  });
+
+  it('keep-server pulls and replaces local state', async () => {
+    const server = populatedLocalState();
+    pullFullState.mockResolvedValueOnce(server);
+    await coordinator.resolveConflict('keep-server');
+    expect(pullFullState).toHaveBeenCalled();
+    expect(clearRemoteState).not.toHaveBeenCalled();
+    expect(get(coordinator.pendingConflict)).toBeNull();
+    expect(get(coordinator.syncStatus)).toBe('saved');
+  });
+
+  it('cancel signs the user out without touching server data', async () => {
+    await coordinator.resolveConflict('cancel');
+    expect(supabaseAuthMock.signOut).toHaveBeenCalled();
+    expect(clearRemoteState).not.toHaveBeenCalled();
+    expect(pushFullState).not.toHaveBeenCalled();
+    expect(get(coordinator.pendingConflict)).toBeNull();
+  });
+});
+
+describe('debounced push', () => {
+  it('does not push when no session is active', async () => {
+    appStateStore.update((state) => ({ ...state, favoriteFlavorId: 'f1' }));
+    await new Promise((r) => setTimeout(r, 80));
+    expect(pushFullState).not.toHaveBeenCalled();
+  });
+
+  it('pushes once after the debounce delay when signed in', async () => {
+    peekRemoteState.mockResolvedValueOnce({
+      exists: true,
+      boxCount: 0,
+      flavorCount: 0,
+      eventCount: 0,
+      updatedAt: '2026-05-14T12:00:00.000Z',
+    });
+    pullFullState.mockResolvedValueOnce(freshLocalState());
+    await fireAuthEvent('SIGNED_IN');
+    pushFullState.mockClear();
+
+    appStateStore.update((state) => ({ ...state, favoriteFlavorId: 'f1' }));
+    appStateStore.update((state) => ({ ...state, favoriteFlavorId: 'f2' }));
+
+    await new Promise((r) => setTimeout(r, 80));
+    expect(pushFullState).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/sync.test.ts
+++ b/tests/unit/sync.test.ts
@@ -202,6 +202,12 @@ describe('peekRemoteState', () => {
     mock.__seedError('snapshot', { message: 'boom' });
     await expect(peekRemoteState()).rejects.toBeInstanceOf(SyncError);
   });
+
+  it('throws SyncError when the event count query fails', async () => {
+    mock.__seedSnapshot({ boxes: [], flavors: [], updated_at: '2026-05-14T12:00:00.000Z' });
+    mock.__seedError('count', { message: 'count failed' });
+    await expect(peekRemoteState()).rejects.toBeInstanceOf(SyncError);
+  });
 });
 
 describe('pullFullState', () => {
@@ -259,6 +265,20 @@ describe('pullFullState', () => {
     expect(state).not.toBeNull();
     expect(state!.version).toBe(3);
     expect(state!.events).toEqual([]);
+  });
+
+  it('throws SyncError when the events query fails', async () => {
+    mock.__seedSnapshot({
+      user_id: 'user-123',
+      version: 3,
+      boxes: [],
+      flavors: [],
+      favorite_flavor_id: null,
+      settings: {},
+      updated_at: '2026-05-14T12:00:00.000Z',
+    });
+    mock.__seedError('events', { message: 'events query failed' });
+    await expect(pullFullState()).rejects.toBeInstanceOf(SyncError);
   });
 
   it('throws SyncError when assembled state fails schema validation', async () => {

--- a/tests/unit/sync.test.ts
+++ b/tests/unit/sync.test.ts
@@ -1,0 +1,336 @@
+/**
+ * Unit tests for the sync module (push/pull/peek/clear).
+ *
+ * Mocks the local `lib/supabase` singleton with a hand-rolled stub that
+ * records every call. Each test resets the stub via `installMockClient`.
+ */
+
+import { describe, it, expect, beforeEach, vi, type Mock } from 'vitest';
+import type { AppState } from '../../src/types/models';
+
+// Hand-rolled query-builder stub. Records calls and returns the data the
+// test seeded for the current chain. Supports the small slice of supabase-js
+// the sync module actually uses.
+interface TableCall {
+  table: string;
+  op: 'select' | 'upsert' | 'delete';
+  args: unknown[];
+  filter?: { column: string; value: unknown };
+}
+
+interface MockClient {
+  auth: {
+    getUser: Mock;
+  };
+  from: Mock;
+  __calls: TableCall[];
+  __seedSnapshot: (row: unknown) => void;
+  __seedEvents: (rows: unknown[]) => void;
+  __seedCount: (n: number) => void;
+  __seedError: (op: 'snapshot' | 'events' | 'count' | 'upsert', err: unknown) => void;
+  __seedUser: (id: string | null) => void;
+}
+
+let mock: MockClient;
+
+function buildMockClient(): MockClient {
+  const calls: TableCall[] = [];
+  let snapshot: unknown = null;
+  let snapshotError: unknown = null;
+  let events: unknown[] = [];
+  let eventsError: unknown = null;
+  let count = 0;
+  let countError: unknown = null;
+  let upsertError: unknown = null;
+  let userId: string | null = 'user-123';
+
+  function from(table: string) {
+    return {
+      select(_cols: string, opts?: { count?: string; head?: boolean }) {
+        const wantsCount = opts?.count === 'exact';
+        return {
+          eq(column: string, value: unknown) {
+            const filter = { column, value };
+            return {
+              async maybeSingle() {
+                calls.push({ table, op: 'select', args: [_cols], filter });
+                if (table === 'app_states') {
+                  return { data: snapshot, error: snapshotError };
+                }
+                return { data: null, error: null };
+              },
+              order() {
+                return {
+                  returns: () => ({
+                    async then(resolve: (v: unknown) => unknown) {
+                      calls.push({ table, op: 'select', args: [_cols], filter });
+                      return resolve({ data: events, error: eventsError });
+                    },
+                  }),
+                };
+              },
+              ...(wantsCount
+                ? {
+                    async then(resolve: (v: unknown) => unknown) {
+                      calls.push({ table, op: 'select', args: [_cols], filter });
+                      return resolve({ count, error: countError });
+                    },
+                  }
+                : {}),
+            };
+          },
+        };
+      },
+      async upsert(rows: unknown, _opts?: unknown) {
+        calls.push({ table, op: 'upsert', args: [rows, _opts] });
+        return { error: upsertError };
+      },
+      delete() {
+        return {
+          async eq(column: string, value: unknown) {
+            calls.push({ table, op: 'delete', args: [], filter: { column, value } });
+            return { error: null };
+          },
+        };
+      },
+    };
+  }
+
+  return {
+    auth: {
+      getUser: vi.fn(async () => ({
+        data: { user: userId ? { id: userId } : null },
+        error: null,
+      })),
+    },
+    from: vi.fn(from),
+    __calls: calls,
+    __seedSnapshot(row) {
+      snapshot = row;
+    },
+    __seedEvents(rows) {
+      events = rows;
+    },
+    __seedCount(n) {
+      count = n;
+    },
+    __seedError(op, err) {
+      if (op === 'snapshot') snapshotError = err;
+      if (op === 'events') eventsError = err;
+      if (op === 'count') countError = err;
+      if (op === 'upsert') upsertError = err;
+    },
+    __seedUser(id) {
+      userId = id;
+    },
+  };
+}
+
+function installMockClient() {
+  mock = buildMockClient();
+  return mock;
+}
+
+vi.mock('../../src/lib/supabase', () => ({
+  get supabase() {
+    return mock;
+  },
+  isSyncConfigured: () => true,
+}));
+
+// Import after vi.mock so the mocked supabase is used.
+const { pushFullState, pullFullState, peekRemoteState, clearRemoteState, SyncError } =
+  await import('../../src/lib/sync');
+const { createDefaultAppState } = await import('../../src/types/models');
+
+const SAMPLE_STATE: AppState = {
+  ...createDefaultAppState(),
+  boxes: [
+    {
+      id: 'box1',
+      flavorId: 'f1',
+      quantity: 5,
+      location: { stack: 0, height: 0 },
+      isOpen: false,
+    },
+  ],
+  flavors: [{ id: 'f1', name: 'Chocolate', randomPool: 'caffeinated' }],
+  events: [
+    {
+      id: 'ev_1',
+      timestamp: '2026-05-14T12:00:00.000Z',
+      type: 'box_received',
+      boxId: 'box1',
+      flavorId: 'f1',
+      quantity: 5,
+      location: { stack: 0, height: 0 },
+      isOpen: false,
+    },
+  ],
+};
+
+beforeEach(() => {
+  installMockClient();
+});
+
+describe('peekRemoteState', () => {
+  it('returns exists:false when no row is present', async () => {
+    mock.__seedSnapshot(null);
+    const summary = await peekRemoteState();
+    expect(summary.exists).toBe(false);
+    expect(summary.boxCount).toBe(0);
+  });
+
+  it('returns counts for boxes/flavors/events when present', async () => {
+    mock.__seedSnapshot({
+      boxes: [{}, {}, {}],
+      flavors: [{}, {}],
+      updated_at: '2026-05-14T12:00:00.000Z',
+    });
+    mock.__seedCount(7);
+    const summary = await peekRemoteState();
+    expect(summary).toEqual({
+      exists: true,
+      boxCount: 3,
+      flavorCount: 2,
+      eventCount: 7,
+      updatedAt: '2026-05-14T12:00:00.000Z',
+    });
+  });
+
+  it('throws SyncError when the snapshot read fails', async () => {
+    mock.__seedError('snapshot', { message: 'boom' });
+    await expect(peekRemoteState()).rejects.toBeInstanceOf(SyncError);
+  });
+});
+
+describe('pullFullState', () => {
+  it('returns null when no row exists', async () => {
+    mock.__seedSnapshot(null);
+    expect(await pullFullState()).toBeNull();
+  });
+
+  it('assembles AppState from snapshot + events', async () => {
+    mock.__seedSnapshot({
+      user_id: 'user-123',
+      version: 3,
+      boxes: SAMPLE_STATE.boxes,
+      flavors: SAMPLE_STATE.flavors,
+      favorite_flavor_id: null,
+      settings: {},
+      updated_at: '2026-05-14T12:00:00.000Z',
+    });
+    mock.__seedEvents([
+      {
+        id: 'ev_1',
+        user_id: 'user-123',
+        type: 'box_received',
+        event_timestamp: '2026-05-14T12:00:00.000Z',
+        payload: {
+          boxId: 'box1',
+          flavorId: 'f1',
+          quantity: 5,
+          location: { stack: 0, height: 0 },
+          isOpen: false,
+        },
+      },
+    ]);
+
+    const state = await pullFullState();
+    expect(state).not.toBeNull();
+    expect(state!.boxes).toHaveLength(1);
+    expect(state!.events).toHaveLength(1);
+    expect(state!.events[0].type).toBe('box_received');
+  });
+
+  it('upgrades a v2 snapshot through the migration pipeline', async () => {
+    mock.__seedSnapshot({
+      user_id: 'user-123',
+      version: 2,
+      boxes: [],
+      flavors: [],
+      favorite_flavor_id: null,
+      settings: {},
+      updated_at: '2026-05-14T12:00:00.000Z',
+    });
+    mock.__seedEvents([]);
+
+    const state = await pullFullState();
+    expect(state).not.toBeNull();
+    expect(state!.version).toBe(3);
+    expect(state!.events).toEqual([]);
+  });
+
+  it('throws SyncError when assembled state fails schema validation', async () => {
+    mock.__seedSnapshot({
+      user_id: 'user-123',
+      version: 3,
+      boxes: 'not an array',
+      flavors: [],
+      favorite_flavor_id: null,
+      settings: {},
+      updated_at: '2026-05-14T12:00:00.000Z',
+    });
+    mock.__seedEvents([]);
+    await expect(pullFullState()).rejects.toBeInstanceOf(SyncError);
+  });
+});
+
+describe('pushFullState', () => {
+  it('upserts app_states and events', async () => {
+    await pushFullState(SAMPLE_STATE);
+
+    const upserts = mock.__calls.filter((c) => c.op === 'upsert');
+    expect(upserts.map((u) => u.table)).toContain('app_states');
+    expect(upserts.map((u) => u.table)).toContain('events');
+  });
+
+  it('skips the events upsert when state.events is empty', async () => {
+    await pushFullState({ ...SAMPLE_STATE, events: [] });
+
+    const tables = mock.__calls.filter((c) => c.op === 'upsert').map((c) => c.table);
+    expect(tables).toContain('app_states');
+    expect(tables).not.toContain('events');
+  });
+
+  it('throws SyncError when upsert fails', async () => {
+    mock.__seedError('upsert', { message: 'fail' });
+    await expect(pushFullState(SAMPLE_STATE)).rejects.toBeInstanceOf(SyncError);
+  });
+
+  it('throws SyncError when getUser returns no user', async () => {
+    mock.__seedUser(null);
+    await expect(pushFullState(SAMPLE_STATE)).rejects.toBeInstanceOf(SyncError);
+  });
+
+  it('splits event fields into payload column correctly', async () => {
+    await pushFullState(SAMPLE_STATE);
+
+    const eventUpsert = mock.__calls.find((c) => c.op === 'upsert' && c.table === 'events');
+    expect(eventUpsert).toBeDefined();
+    const rows = eventUpsert!.args[0] as Array<{
+      id: string;
+      type: string;
+      event_timestamp: string;
+      payload: Record<string, unknown>;
+    }>;
+    expect(rows[0].id).toBe('ev_1');
+    expect(rows[0].type).toBe('box_received');
+    expect(rows[0].event_timestamp).toBe('2026-05-14T12:00:00.000Z');
+    // id/timestamp/type should NOT appear inside payload
+    expect(rows[0].payload).not.toHaveProperty('id');
+    expect(rows[0].payload).not.toHaveProperty('timestamp');
+    expect(rows[0].payload).not.toHaveProperty('type');
+    expect(rows[0].payload.boxId).toBe('box1');
+  });
+});
+
+describe('clearRemoteState', () => {
+  it('deletes events then app_state for the current user', async () => {
+    await clearRemoteState();
+    const deletes = mock.__calls.filter((c) => c.op === 'delete');
+    expect(deletes).toHaveLength(2);
+    expect(deletes[0].table).toBe('events');
+    expect(deletes[1].table).toBe('app_states');
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,20 @@ import dotenv from 'dotenv';
 // Load .env.local if it exists (for worktree-specific port configuration)
 dotenv.config({ path: '.env.local' });
 
+// Resolve Supabase config from the available env-var aliases. Locally we
+// read VITE_SUPABASE_* from .env.local; on Vercel the Supabase integration
+// injects SUPABASE_URL and SUPABASE_PUBLISHABLE_KEY (along with several
+// server-only secrets we deliberately ignore). We safelist by NAME to keep
+// SUPABASE_SERVICE_ROLE_KEY / SUPABASE_SECRET_KEY / SUPABASE_JWT_SECRET /
+// POSTGRES_PASSWORD out of the client bundle — widening Vite's envPrefix
+// would expose them all.
+const supabaseUrl = process.env.VITE_SUPABASE_URL ?? process.env.SUPABASE_URL ?? '';
+const supabaseAnonKey =
+  process.env.VITE_SUPABASE_ANON_KEY ??
+  process.env.SUPABASE_PUBLISHABLE_KEY ??
+  process.env.SUPABASE_ANON_KEY ??
+  '';
+
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [
@@ -83,6 +97,13 @@ export default defineConfig({
   ],
   server: {
     port: parseInt(process.env.VITE_PORT || '5173'),
+  },
+  define: {
+    // Map the resolved Supabase config onto the VITE_SUPABASE_* names the
+    // client reads. Empty strings fall through to lib/supabase.ts's
+    // "not configured" path, which renders local-only mode without crashing.
+    'import.meta.env.VITE_SUPABASE_URL': JSON.stringify(supabaseUrl),
+    'import.meta.env.VITE_SUPABASE_ANON_KEY': JSON.stringify(supabaseAnonKey),
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- **PR 2 of 3** toward a multi-device data backend (PR 1 shipped the local event timeline; PR 3 will add realtime + offline queue + conflict resolution).
- Adds a Supabase backend with two RLS-protected tables (`app_states` snapshot + `events` append-only timeline), magic-link auth, and a debounced push / pull-on-start sync coordinator.
- Sign-in is optional and lives in the Inventory page next to Backup. When local and server both have data, a conflict modal lets you pick which side wins.
- The app gracefully degrades to local-only when the Supabase env vars are missing — no crash, just a friendly notice in the Sync modal.

## What's deliberately out of scope
- Realtime subscriptions, offline queue, field-level merge — PR 3.
- E2E auth tests — would need a real Supabase or extensive mocking; deferred.
- Reporting UI on top of the timeline — out of scope for the data-backend track.

See `docs/adr/012-supabase-sync.md` for rationale and alternatives.

## Setup before this can run end-to-end
Detailed in `supabase/README.md`. Short version:
1. `brew install supabase/tap/supabase`
2. Create a Supabase project; `supabase link --project-ref <ref>`; `supabase db push`
3. Add `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` to `.env.local` and Vercel env vars
4. Add `https://brotein-buddy.vercel.app` and `http://localhost:5173` to the Supabase auth redirect URL allowlist

Without these the app still works — the Sync modal just shows a "not configured" notice.

## Test plan
- [x] `npm test` — 562 unit tests pass (33 new: 13 sync, 13 coordinator, 7 auth)
- [x] `npm run test:e2e` — 347 e2e tests pass, 0 failed (the new auth surface is excluded from e2e by design)
- [x] `npm run check` — svelte-check clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npm run build` — production bundle builds (+24 KiB precache for supabase-js)

🤖 Generated with [Claude Code](https://claude.com/claude-code)