### PR TITLE
Track CLAUDE.md in git and refresh content for 2026

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,8 +25,7 @@ lerna-debug.log*
 # Shared directory - personal files not committed
 /.shared/
 
-# Confidential context (if symlinked to root)
-CLAUDE.md
+# Confidential context (still symlinked from .shared/; do not commit)
 CLAUDE_CONTEXT.md
 
 # Planning and scratch (if symlinked to root)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,83 @@
+# BroteinBuddy
+
+A Progressive Web App for tracking protein shake inventory by flavor and location.
+
+## Tech stack
+
+- Svelte 5 (runes mode) + TypeScript
+- Vite (with PWA plugin)
+- Vitest (unit/integration), Playwright (E2E), `@testing-library/svelte`
+- LocalStorage for offline persistence
+- Supabase (Postgres + Auth) for multi-device sync via magic-link
+- Deployed on Vercel
+
+## Key features
+
+- Weighted random flavor selection
+- Visual inventory with drag-and-drop rearrange
+- Box location tracking with conflict resolution
+- Configurable favorite-flavor quick-pick
+- Smart box selection (open before unopened, lower qty first)
+- Multi-device sync with offline resilience and event timeline
+- In-app Backup & Restore
+
+## Workflow standards
+
+All work happens in a short-lived worktree branched from `main`, squash-merged, then the worktree is deleted. See the `git-github-workflow` skill for branch-naming conventions, the worktree setup script, and post-merge cleanup. **The skill is canonical for mechanics; this file states the requirements and links out.**
+
+### Process before every merge
+
+1. **Plan-stage critique.** Draft the plan in plan mode. Before presenting the plan for approval, launch a fresh-context plan-critique subagent — a structured devil's advocate willing to attack the premise, the approach, and the design. Incorporate its critique where it has merit. Default cap: one pass. A second pass is permitted only if the first surfaced structural objections that materially reshaped the plan. Skip entirely for changes that fit in one sentence (Anthropic's own guidance).
+
+2. **Implement.** Many small commits as work progresses.
+
+3. **Local checks pass.** `npm test`, `npm run lint`, `npm run build`.
+
+4. **Fresh-context code review.** Spawn a new `code-reviewer` subagent in a clean session. The reviewer reads only the diff and the existing codebase. **It does NOT read the PR description, planning docs, or commit messages** — those leak authorial intent and measurably bias the review. (See `git-github-workflow/references/code-reviewer-guide.md`.)
+
+5. **Address blockers.** Small commits per fix. Re-run the fresh-context review if post-review changes are non-trivial.
+
+6. **Teaching-mentor write-up.** After the user confirms ready to merge, invoke the `teaching-mentor` subagent to author an educational document in `docs/teaching/` describing the final delivered state — concepts, trade-offs, design choices a future reader would learn from. Commit to the same branch. (See `git-github-workflow/references/teacher-mentor-guide.md`.)
+
+7. **Squash-merge. Remove worktree. Delete branch.**
+
+### Notes on the critique steps
+
+- **Framing.** Plan-stage critique is "structured devil's advocate" — pushy and willing to attack the premise, but not theatrically adversarial. Aggressive framing measurably increases downstream sycophantic deference.
+- **Context asymmetry.** The plan-stage critic SHOULD see the goal and the plan (the plan IS intent at this stage). The code-review critic should NOT see authorial intent (PR description / commit metadata / planning docs). Different stages, different blinding.
+- **Exit signal.** A critic must explicitly say "no material issues" when there are none. Do not reward critics that invent issues to justify their turn.
+- **When to skip.** Single-line / single-file / typo / rename. Anything where the diff describes itself in one sentence.
+
+## Testing requirements
+
+- 90% coverage overall, 100% for critical paths.
+- All tests pass before merge. Husky pre-commit hooks enforce ESLint + Prettier.
+
+## Project structure
+
+```
+BroteinBuddy/
+├── .bare/             # bare git repository
+├── .shared/           # personal files (not tracked): CLAUDE_CONTEXT.md, .planning/, .scratch/, .claude/
+├── main/              # main branch worktree
+├── <branch-dir>/      # short-lived worktrees (deleted after merge)
+├── src/               # source
+├── tests/             # unit + e2e
+└── docs/              # ADRs (docs/adr/) and teaching docs (docs/teaching/)
+```
+
+## Documentation
+
+- `README.md` — user-facing.
+- `DEVELOPING.md` — developer-facing (architecture, conventions, deeper setup).
+- `docs/adr/` — Architecture Decision Records.
+- `docs/teaching/` — Educational write-ups, one per merged change, authored by the `teaching-mentor` subagent.
+
+## Claude Code infrastructure
+
+Project-specific skills and subagents are symlinked into each worktree by the setup script:
+
+- **Skills:** `git-github-workflow`, `brotein-buddy-standards`.
+- **Subagents:** `code-reviewer` (fresh-context diff reviewer), `teaching-mentor` (educational docs).
+
+Skill / subagent sources live in `~/Code/repos/custom-claude-skills/` and `~/Code/repos/custom-claude-agents/`. See `DEVELOPING.md` for the symlink layout.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,13 +27,13 @@ All work happens in a short-lived worktree branched from `main`, squash-merged, 
 
 ### Process before every merge
 
-1. **Plan-stage critique.** Draft the plan in plan mode. Before presenting the plan for approval, launch a fresh-context plan-critique subagent — a structured devil's advocate willing to attack the premise, the approach, and the design. Incorporate its critique where it has merit. Default cap: one pass. A second pass is permitted only if the first surfaced structural objections that materially reshaped the plan. Skip entirely for changes that fit in one sentence (Anthropic's own guidance).
+1. **Plan-stage critique.** Draft the plan in plan mode. Before presenting the plan for approval, launch a fresh-context `Task` (`Plan` subagent type, framed as a structured devil's advocate) and pass it the goal and the current plan file. It should be willing to attack the premise, the approach, and the design. Incorporate its critique where it has merit. Default cap: one pass. A second pass is permitted only if the first surfaced structural objections that materially reshaped the plan. Skip entirely for changes that fit in one sentence.
 
 2. **Implement.** Many small commits as work progresses.
 
 3. **Local checks pass.** `npm test`, `npm run lint`, `npm run build`.
 
-4. **Fresh-context code review.** Spawn a new `code-reviewer` subagent in a clean session. The reviewer reads only the diff and the existing codebase. **It does NOT read the PR description, planning docs, or commit messages** — those leak authorial intent and measurably bias the review. (See `git-github-workflow/references/code-reviewer-guide.md`.)
+4. **Fresh-context code review.** Spawn a new `code-reviewer` subagent in a clean session. The reviewer reads only the diff and the existing codebase. **It does NOT read the PR description, planning docs, or commit messages** — those leak authorial intent and bias the review. (This supersedes earlier guidance in `git-github-workflow/references/code-reviewer-guide.md`, which is being updated in a follow-up PR to match.)
 
 5. **Address blockers.** Small commits per fix. Re-run the fresh-context review if post-review changes are non-trivial.
 
@@ -43,7 +43,7 @@ All work happens in a short-lived worktree branched from `main`, squash-merged, 
 
 ### Notes on the critique steps
 
-- **Framing.** Plan-stage critique is "structured devil's advocate" — pushy and willing to attack the premise, but not theatrically adversarial. Aggressive framing measurably increases downstream sycophantic deference.
+- **Framing.** Plan-stage critique is "structured devil's advocate" — pushy and willing to attack the premise, but not theatrically adversarial. Aggressive framing has been shown to increase downstream sycophantic deference rather than improve outcomes.
 - **Context asymmetry.** The plan-stage critic SHOULD see the goal and the plan (the plan IS intent at this stage). The code-review critic should NOT see authorial intent (PR description / commit metadata / planning docs). Different stages, different blinding.
 - **Exit signal.** A critic must explicitly say "no material issues" when there are none. Do not reward critics that invent issues to justify their turn.
 - **When to skip.** Single-line / single-file / typo / rename. Anything where the diff describes itself in one sentence.
@@ -77,7 +77,7 @@ BroteinBuddy/
 
 Project-specific skills and subagents are symlinked into each worktree by the setup script:
 
-- **Skills:** `git-github-workflow`, `brotein-buddy-standards`.
+- **Skills:** `git-github-workflow` (worktree mechanics, branch naming, PR + merge flow), `brotein-buddy-standards` (testing thresholds, lint/format, doc structure).
 - **Subagents:** `code-reviewer` (fresh-context diff reviewer), `teaching-mentor` (educational docs).
 
 Skill / subagent sources live in `~/Code/repos/custom-claude-skills/` and `~/Code/repos/custom-claude-agents/`. See `DEVELOPING.md` for the symlink layout.

--- a/docs/teaching/0.5-workflow-as-codified-process.md
+++ b/docs/teaching/0.5-workflow-as-codified-process.md
@@ -1,0 +1,327 @@
+# Codifying a Workflow in `CLAUDE.md`: Why Two Critic Stages, Why Different Blinding, and Why a Tracked File
+
+**Deliverable:** 0.5 — Track `CLAUDE.md` in git and codify the multi-stage merge workflow (PR #98, branch `docs/claude-md-refresh`)
+**Author:** Claude Code (Teaching Mentor Subagent)
+**Date:** 2026-05-21
+**Skill Level:** Foundational / Process
+
+---
+
+## Table of Contents
+
+1. [What We Built](#what-we-built)
+2. [Why This Approach](#why-this-approach)
+   - [The Problem We Solved](#the-problem-we-solved)
+   - [Two Problems, One PR](#two-problems-one-pr)
+3. [How It Works](#how-it-works)
+   - [Part 1 — From Symlink to Tracked File](#part-1--from-symlink-to-tracked-file)
+   - [Part 2 — The Seven-Step Process](#part-2--the-seven-step-process)
+   - [Part 3 — The Critic-Context Asymmetry](#part-3--the-critic-context-asymmetry)
+4. [Design Trade-offs](#design-trade-offs)
+   - [Structured Devil's Advocate vs. "Adversarial"](#structured-devils-advocate-vs-adversarial)
+   - [Default Cap of One Pass, Not Two](#default-cap-of-one-pass-not-two)
+   - [Why CLAUDE.md States Requirements and the Skill States Mechanics](#why-claudemd-states-requirements-and-the-skill-states-mechanics)
+   - [Sequencing: Why This PR Shipped Before the Bugfix](#sequencing-why-this-pr-shipped-before-the-bugfix)
+5. [Real-World Compromises](#real-world-compromises)
+6. [The Workflow Eating Its Own Cooking](#the-workflow-eating-its-own-cooking)
+7. [What You Should Learn From This](#what-you-should-learn-from-this)
+8. [Going Deeper](#going-deeper)
+9. [Questions to Think About](#questions-to-think-about)
+
+---
+
+## What We Built
+
+Two things, tightly braided.
+
+The first is a one-file move: `CLAUDE.md`, the document Claude Code reads at the start of every session to learn what this project is, moved out of a personal symlink in `.shared/` and became a **tracked file in the git repo**. The diff itself is small — `git mv` in spirit, a `.gitignore` line removed, an `init-shared.sh` heredoc deleted — but the second-order effects are large. Project context now has a real edit history. Reviewers see changes to it in diffs. New worktrees get it via `git checkout` instead of via a brittle symlink that the worktree setup script had to remember to create.
+
+The second is the content the tracked file now holds. We rewrote `CLAUDE.md` for the 2026 codebase (Supabase sync, offline event timeline, Backup & Restore — none of which existed when the old file was written) and, more importantly, **codified the merge workflow we have been informally practicing into a seven-step process every change now has to walk through before it lands on `main`**. The interesting part of that codification isn't the steps themselves. It's the asymmetric rules about what each critic stage is allowed to see — and the deliberate decision not to escalate the number of critique passes.
+
+The PR exercised every one of those steps on itself. Including the code-review step, which surfaced real issues — issues you can see addressed in two follow-up commits on the branch. We'll come back to that, because it's the most instructive part.
+
+## Why This Approach
+
+### The Problem We Solved
+
+`CLAUDE.md` had been a symlink. Every worktree pointed at the same physical file living under `.shared/CLAUDE.md`. That setup made sense when the project started — `.shared/` is where personal, non-tracked stuff lives (the confidential context file, the planning directory, the scratch directory, local Claude settings) — and bundling `CLAUDE.md` in with the rest was the path of least resistance.
+
+But over time it grew three problems that compound each other.
+
+**Invisibility to git.** `.gitignore` had a line that said `CLAUDE.md`, so the file was never under version control. There was no edit history. There was no way to review a change to it. There was no way to see "when did the testing standards line get added," because git didn't know there was anything to track. The most-referenced file in the project — the one Claude Code loads first, every session, before doing anything else — was off the books.
+
+**Dual source-of-truth risk.** The worktree setup script (`setup-worktree.py`) was responsible for symlinking the file into every new worktree. The actual file lived at `.shared/CLAUDE.md`. If you opened a worktree, edited the file you saw there, and committed your other work, you had silently mutated the master copy used by every other worktree. There was no boundary between "this is the project's context" and "this is my local context." Editing one was editing the other, and there was no review step in between.
+
+**Propagation friction.** When the file did change, propagation depended on the symlink existing in every worktree. If a worktree was created with an older version of the setup script, or if the symlink ever got accidentally clobbered (a `git stash pop` after a rename can do this; so can a careless `rm -rf`), that worktree would be silently out of date — but its content would still look reasonable, because the old symlink target had reasonable content.
+
+Tracking the file in git fixes all three at once. The file has an edit history. It propagates the same way any other file propagates: through commits, through checkouts, through pull requests, through review.
+
+### Two Problems, One PR
+
+Now, the migration alone would have been a small, boring PR. A one-paragraph commit message and twelve lines of `.gitignore` and `init-shared.sh` cleanup. But we deliberately bundled it with a content rewrite, and the content rewrite is the more substantial half.
+
+The reason for bundling: if you're going to turn a file into a tracked, reviewable artifact, the first commit that lands it in git is the one where its content gets the closest reading anyone will ever give it. That's the moment to do the substantive cleanup — drop the obsolete bits, add the now-canonical bits, decide what the file is _for_ — because the diff that does the migration is also the diff a future reader will use to understand the file's intent.
+
+What we added to the content was the seven-step workflow that you'll see in the next section. That workflow had been operating informally for months. Some of it lived in skill files, some lived in habit, some lived in the user's head, and the parts that lived in skill files didn't fully agree with the parts that lived in the user's head. The PR was the forcing function to write it all down in one place and reconcile the disagreements.
+
+## How It Works
+
+### Part 1 — From Symlink to Tracked File
+
+The mechanical migration was three changes.
+
+**Drop the exclusion.** `.gitignore` had this:
+
+```diff
+- # Confidential context (if symlinked to root)
+- CLAUDE.md
++ # Confidential context (still symlinked from .shared/; do not commit)
+  CLAUDE_CONTEXT.md
+```
+
+Note what stayed: `CLAUDE_CONTEXT.md` is confidential context (job-application material, personal notes the user wants nearby but not on GitHub). That one stays excluded. Only the project-facing `CLAUDE.md` becomes tracked.
+
+**Stop seeding stale content from the setup script.** `init-shared.sh` used to write a 2025-era heredoc into `.shared/CLAUDE.md` every time it ran. With `CLAUDE.md` now tracked, the heredoc would create orphaned, stale content right next to the real tracked file every time someone re-initialized `.shared/`. So the whole heredoc came out, replaced with a short comment that explains why it's gone:
+
+```bash
+# CLAUDE.md is no longer created here. It is now a tracked file in the
+# repo and is populated into every worktree by `git checkout` automatically.
+# This script only seeds the files that remain personal / shared-local.
+```
+
+This change came from the fresh-context code review — the reviewer noticed the heredoc and flagged that it would silently re-create stale content. That's exactly the kind of subtle, second-order problem fresh-context reviews are good at catching.
+
+**Write the file as a real tracked file.** The new `main/CLAUDE.md` is no longer a symlink. It's the canonical artifact. New worktrees get it via `git checkout` like any other tracked file — no symlink step, no setup-script logic to remember.
+
+There's a migration sequence the PR body spells out, and it matters: the companion `custom-claude-skills` PR has to merge **first**, removing the `CLAUDE.md` symlink step from `setup-worktree.py`, otherwise any worktree created after this PR lands would have its tracked `CLAUDE.md` immediately overwritten by a symlink. Two PRs, hard-ordered. That ordering constraint is the kind of thing that should be obvious in retrospect and is easy to miss in the moment.
+
+### Part 2 — The Seven-Step Process
+
+Here's the workflow the refreshed `CLAUDE.md` now codifies, lifted straight from the file:
+
+```
+1. Plan-stage critique  ← structured devil's advocate, fresh context
+2. Implement            ← many small commits
+3. Local checks pass    ← npm test, lint, build
+4. Fresh-context code review  ← diff only, no PR description visible
+5. Address blockers     ← small commits per fix
+6. Teaching-mentor write-up   ← docs/teaching/ (this document!)
+7. Squash-merge, remove worktree, delete branch
+```
+
+Each step is doing a specific job. Let's walk through what's interesting about each, because the order and the framing matter.
+
+**Step 1 — Plan-stage critique.** Before you write code, you draft a plan in plan mode. Before you present that plan for approval, you spawn a fresh-context Task (the `Plan` subagent type, framed as a "structured devil's advocate") and hand it the goal and the plan file. It is allowed — encouraged — to attack the premise. "Is the goal even the right goal?" "Is this approach the right approach?" "Is there a simpler way?" It is not a rubber stamp. The default cap is **one pass**. A second pass is permitted only if the first pass surfaced structural objections that materially reshaped the plan. We'll come back to why one and not two.
+
+**Step 2 — Implement.** Many small commits as work progresses, not one big commit at the end. This isn't unique to this workflow — it's just good hygiene — but it's listed because step 4 (code review) reads the diff cumulatively. Granular commits give the reviewer the option to read commit-by-commit if they want. Big retrospective commits collapse the history into one blob and force a single read.
+
+**Step 3 — Local checks pass.** `npm test`, `npm run lint`, `npm run build`. Nothing exotic. The point is that these have to pass before step 4, because spending a reviewer's attention on code that doesn't compile is a waste.
+
+**Step 4 — Fresh-context code review.** This is the most interesting step. A new `code-reviewer` subagent is spawned in a clean session — no inherited context from the planning conversation, no inherited context from the implementation conversation. It reads only the diff and the existing codebase. **It does NOT read the PR description, the planning docs, or the commit messages.** Why? Because all three of those leak _authorial intent_, and a reviewer who knows what you were trying to do reads code differently from a reviewer who has to figure out what you were trying to do. We'll devote a whole section to this asymmetry below — it's worth a section of its own.
+
+**Step 5 — Address blockers.** If the reviewer flags real problems, you fix them in small commits on the branch and, if the changes are non-trivial, re-run the fresh-context review on the updated diff. Crucially: the workflow assumes the reviewer will sometimes flag things you disagree with, and the appropriate response is to address them on the merits, not to defer to the reviewer just because they spoke last.
+
+**Step 6 — Teaching-mentor write-up.** This document. After the user confirms ready to merge, the teaching-mentor subagent is invoked to write an educational document in `docs/teaching/` describing what was delivered and why, in a patient mentoring voice, for a future reader who has never seen this PR. The point is to ratchet the codebase's institutional knowledge upward, one PR at a time.
+
+**Step 7 — Squash-merge.** All those small commits collapse into one commit on `main`. The branch is deleted. The worktree is removed. The next change starts fresh.
+
+That last step is the reason the small commits in step 2 are fine: they're scaffolding. They exist for the reviewer's benefit during review, not for `main`'s benefit afterward. `main` gets one clean commit per change, with a clean message, and the dev-time noise stays in the (now-deleted) feature branch.
+
+### Part 3 — The Critic-Context Asymmetry
+
+Both step 1 and step 4 are "spawn a fresh-context critic." Both critics start with no inherited conversation history. So far, symmetric. But what each one is allowed to read is deliberately, surgically different.
+
+**The plan-stage critic SHOULD see the goal and the plan.** Because at this stage, the plan _is_ intent. The plan exists exactly to make intent legible. If you blind the plan-stage critic to the goal, they can't critique it — they can only critique the plan in the abstract, divorced from whether the plan serves the goal. So at step 1, the critic gets the goal, the plan file, and the codebase context they need to reason about feasibility.
+
+**The code-review critic should NOT see authorial intent.** Different stage, different blinding. By step 4, the code is the artifact. The PR description, the commit messages, the planning doc — these all say "here is what I _intended_ this code to do." A reviewer who reads them goes into the diff with a mental model already formed; they verify the code matches the description, and they tend to miss problems _that are not about that match_. That's the bias the asymmetry is guarding against.
+
+Concretely: imagine the PR description says "this fix adds null-safety to the storage layer," and the diff really does add null-safety to the storage layer — and also, in passing, refactors a separate function in a way that breaks its semantics. A reviewer who read the description will verify the null-safety change and probably skim over the unrelated refactor, because the refactor isn't what they're "supposed to" be looking at. A reviewer who only sees the diff has no preconception of what's "supposed to" be there; they read all of it with equal weight.
+
+This is the same intuition that double-blind peer review is built on. The author's framing of what the work is _about_ biases what readers attend to. Removing that framing makes the readers attend to everything more evenly.
+
+Here's the diagram of it side by side:
+
+```
+Stage 1: Plan-stage critique
++---------------------------+
+| Critic sees:              |
+|   - The goal              |
+|   - The plan file         |
+|   - Codebase context      |
+| Critic does NOT see:      |
+|   - (n/a — no code yet)   |
++---------------------------+
+
+Stage 4: Fresh-context code review
++---------------------------+
+| Critic sees:              |
+|   - The diff              |
+|   - The existing codebase |
+| Critic does NOT see:      |
+|   - PR description        |
+|   - Planning docs         |
+|   - Commit messages       |
+|   - Implementation chat   |
++---------------------------+
+```
+
+Same "fresh context" framing. Different blinding rules. The reason that's not arbitrary is that the two stages are doing different jobs: one is reasoning about a not-yet-built thing (and needs intent to do that), the other is reading a built thing (and is biased by intent).
+
+## Design Trade-offs
+
+### Structured Devil's Advocate vs. "Adversarial"
+
+The plan-stage critic is framed as a "structured devil's advocate" — pushy and willing to attack the premise, but not theatrically adversarial. That word choice matters.
+
+The intuitive move is to crank the framing up: "be brutal," "spare nothing," "tear it apart." The research on critique-loop framing in LLMs has been showing for a couple of years now that aggressive framing has a perverse effect: it produces critics that find more issues, but the issues are lower-quality (some are spurious, some are stylistic), and the downstream conversation becomes _more_ sycophantic, not less — once the original author backs down on a few aggressive critiques, the model that wrote the code starts deferring on critiques it should push back on. The signal-to-noise on the critique gets worse, and the author's epistemic posture gets worse with it.
+
+"Structured devil's advocate" threads the needle. The critic is licensed to attack the premise — it isn't a rubber stamp — but it's licensed to attack on substance, not on theatrics. The framing keeps the critic skeptical without tilting the conversation into performance.
+
+### Default Cap of One Pass, Not Two
+
+The default cap on plan-stage critique is one pass. A second pass is permitted, but only if the first pass surfaced structural objections that materially reshaped the plan. The system does not _require_ two passes; it requires one and permits a conditional second.
+
+This is a deliberate choice against the "more is better" intuition. Replications of the early reflection-and-revise work — the Reflexion line of papers and its follow-ups — converged on a finding that the marginal value of additional critique passes drops sharply after the first, and that by pass three or four you're often making the work worse: the critic starts finding "issues" that justify its own turn, the author starts over-revising, and the result is a polished-but-wrong artifact rather than a useful one.
+
+Capping the default at one and permitting a conditional second pass keeps the workflow honest: a second pass has to be _earned_ by the first surfacing something real. If the first pass returns "no material issues," that's the exit signal, and you proceed. **No critic in this workflow is rewarded for inventing issues to justify its turn** — that's another explicit line in the file. A critic that wants to add value has to say so when there's no value to add.
+
+### Why CLAUDE.md States Requirements and the Skill States Mechanics
+
+There's a related skill — `git-github-workflow` — that has long owned the mechanics: branch naming, worktree setup scripts, post-merge cleanup, the exact arguments to `setup-worktree.py`. We could have folded the workflow standards into that skill and called it done.
+
+We didn't, for a specific reason: **dual-source-of-truth drift**. If both `CLAUDE.md` and the skill describe "the workflow," and one of them changes, the two drift apart and a future reader has to figure out which is canonical. The rule we landed on is: `CLAUDE.md` states the _requirements_ — what every change must do before it merges — and links out to the skill for the _mechanics_. The skill owns "here is the exact command to create a worktree." `CLAUDE.md` owns "every change must happen in a short-lived worktree."
+
+Whenever you have two documents in a codebase that overlap, ask: which one is canonical for which audience? In this case, `CLAUDE.md` is the document loaded automatically at the start of every Claude Code session — it's read more often than anything else in the repo — so it should be the requirements-stating document. The skill is what you read when you need to know exactly which command to run; it should be the mechanics-stating document. Two documents, two jobs, one direction of reference (`CLAUDE.md` → skill, never back).
+
+### Sequencing: Why This PR Shipped Before the Bugfix
+
+The user is also working on a real bugfix — the Rearrange screen is not scrollable on small viewports — and the original plan was to ship the bugfix first and the workflow refresh second. The order was deliberately flipped.
+
+The reasoning: if the workflow refresh is the document that codifies how every change merges, then the bugfix that ships under the old (unwritten) workflow becomes the one change in recent history that didn't follow the new rules. Flipping the order means the bugfix is the **first end-to-end exercise** of the new workflow, not a fossilized exception to it. It's a small thing, but it matters for the credibility of the codified process: the document doesn't say "we did this once and then started following these rules"; the document says "here are the rules, and the very next thing we merged followed them."
+
+There's also a non-decorative consequence: if the bugfix had merged first, this PR's seven-step process would have been a description of what we _hoped_ to do. By merging this PR first, the seven-step process becomes a description of what we _just did_ — including, crucially, the part where the fresh-context code review surfaced real findings and we fixed them in follow-up commits. The next section is that story.
+
+## Real-World Compromises
+
+### The `.shared/CLAUDE.md` Dead-Letter
+
+The cleanest possible migration would delete `.shared/CLAUDE.md` in the same PR that adds the tracked `CLAUDE.md`. We didn't, and the PR body is explicit about why: while the PR is in review, `main/`'s `CLAUDE.md` is still a symlink pointing at `.shared/CLAUDE.md`. If we delete the symlink target pre-merge, we break `main/`'s active session. The fix is a post-merge cleanup step — documented in the PR's "Migration steps after merge" — but it's a temporary period where two copies of the file exist, and a future contributor opening the repo during that window would see both and be confused.
+
+This is the kind of compromise that exists because git's atomicity stops at the commit boundary. Inside one PR, you can't both "remove the symlink target" and "rely on the symlink continuing to work for the active worktree." You have to pick a moment. We picked "after merge," documented the steps, and accepted a brief window of dual-state in exchange for not breaking the active session.
+
+### The Three-Bullet `.bare/info/exclude` Note
+
+`.bare/info/exclude` is the bare-repo equivalent of `.gitignore`. The original draft of the PR considered cleaning it up in the same commit. It got dropped from the diff because `.bare/info/exclude` isn't even git-tracked — it's local to the user's clone — so a PR can't really "clean it up" for anyone except the author. The fix happened in the author's clone; the PR body notes it as a "not in this PR" item. Real cleanup of personal local state belongs in a different kind of artifact (a setup script, a docs note, a one-liner instruction in a README) than in a PR diff.
+
+### Three Pre-Existing Symlink Modifications, Reset
+
+While doing this work, the author noticed three tracked `.claude/` symlinks had wrong relative paths (`../../../` where `../../` was correct). Tempting to fix in the same PR. Wrong to fix in the same PR — they're unrelated to the workflow refresh, they'd inflate the diff, and they'd make the PR harder to review by mixing two distinct topics. They got reset and listed as a "deserves its own focused PR" item in the PR body.
+
+The general rule: when you're working on a focused PR and you notice an unrelated cleanup, write it down somewhere — an issue, a PR-body note, a TODO comment — and resist the urge to bundle it. The bundled version always feels efficient in the moment and always makes the review harder.
+
+### The Code Review Found Things. Good.
+
+The fresh-context code reviewer flagged ten findings on the first pass — seven concerns and three nits. Five of the seven concerns were addressed in two follow-up commits on this branch. The PR body has a table of them. Among the issues caught:
+
+- The text in step 4 pointed at `code-reviewer-guide.md` as the matching reference, but that guide explicitly tells reviewers to consume the PR description and planning context — directly contradicting this PR's "no PR description, no planning docs" rule. The reviewer noticed the contradiction. Fix: call out that the guide is being updated in a follow-up PR, and that `CLAUDE.md` is the canonical side for now.
+
+- Step 1 originally said "fresh-context plan-critique subagent," implying a named subagent that doesn't exist in `custom-claude-agents/`. A future agent following `CLAUDE.md` would try to invoke it and fail. Fix: reword to "fresh-context `Task` (`Plan` subagent type, framed as a structured devil's advocate)" — which is actually invokable.
+
+- `init-shared.sh` was still writing a stale 2025-era CLAUDE.md heredoc into `.shared/`. The reviewer noticed this and called it out. Fix: remove the heredoc, document why, update the success-message bullets.
+
+- Several lines used the word "measurably" ("measurably bias the review," "measurably increases sycophantic deference") without citing anything. The reviewer flagged this as research-flavored authority claims without actual references. Fix: soften to project conventions and observed findings, and let the contradiction with the existing guide do the work that the "measurably" hedge was doing.
+
+That last one is interesting on its own. The first draft was using "measurably" as a confidence marker borrowed from the surrounding research, but in a project document not backed by inline citations, it reads as ornament — as the kind of phrase a confident person would use to win an argument. The reviewer caught it. The fix made the prose stand on its own.
+
+**This is what the workflow is for.** A fresh-context reviewer, with no knowledge of the author's intent, found real problems that a context-rich reviewer might have skipped past. That's not a defect of the workflow; it's the point. The exact same workflow then required us to address the findings on the merits and either fix them or document why we wouldn't — which we did, in two follow-up commits and an explicit table in the PR body marking what was addressed and what was deferred.
+
+## The Workflow Eating Its Own Cooking
+
+The reason this PR is more instructive than its diff suggests is that it was the first thing to walk through its own newly-codified process. Every step happened:
+
+1. **Plan-stage critique.** A `Plan` subagent reviewed the plan before any code was written; it surfaced eighteen points, several of which materially reshaped the plan (the bugfix-first sequencing got flipped to workflow-first; the dead-letter `.shared/CLAUDE.md` deletion got pulled into the explicit migration steps).
+2. **Implement.** Three commits on the branch: the initial tracked-file commit, the heredoc cleanup, the code-review-feedback fixes.
+3. **Local checks pass.** All tests, lint, and build green.
+4. **Fresh-context code review.** Ten findings; five addressed.
+5. **Address blockers.** Two follow-up commits, each with explicit references to the review findings they were addressing.
+6. **Teaching-mentor write-up.** This document.
+7. **Squash-merge.** Pending.
+
+The most teachable thing about this PR isn't any individual step. It's that the workflow was demanding enough on its own author — the very person writing the rules — to find real bugs in the rules' first draft. The "fresh-context plan-critique subagent" phrasing in step 1 didn't survive contact with the reviewer because that subagent doesn't actually exist by that name. A workflow that catches its own ambiguities on its first pass through is a workflow that is doing its job.
+
+## What You Should Learn From This
+
+### 1. Track What You Reference
+
+If a file is the most-referenced document in your workflow, it belongs in version control. The instinct to keep personal-feeling content in a personal-feeling place (`.shared/`, `~/dotfiles/`, "I'll just remember this") is the same instinct that gradually buries institutional knowledge in places only the original author can find it. The cost of tracking is a `.gitignore` change. The value of tracking is every future contributor seeing the same content, with the same edit history, and being able to review changes to it.
+
+**When to apply:** Any file whose purpose is to brief a collaborator (human or AI) on what the project is, how it works, or how to contribute to it. README files. Architecture docs. Workflow docs. CLAUDE.md.
+
+**When not to apply:** Confidential or personal content. Job-application materials. Local environment notes. Things that genuinely should not leave the author's machine. `CLAUDE_CONTEXT.md` stays excluded, and that's correct.
+
+### 2. Pre-Implementation Critique Is Cheaper Than Post-Implementation Fix
+
+The plan-stage critique step exists because catching a bad approach _before_ writing code is dramatically cheaper than catching it after. The bugfix-first sequencing in this PR's original plan would have shipped a bugfix that didn't follow its own newly-codified process. A plan-stage critic caught that and the order was flipped — at zero code-cost. If we'd discovered it post-merge, the unwinding cost would have been an extra PR explaining the order-of-operations footgun.
+
+**When to apply:** Any change where the approach itself has trade-offs — sequencing, architecture, scope, framework choice. Anything where "did we pick the right shape?" is a meaningful question.
+
+**When to skip:** Single-line changes, typo fixes, renames, mechanical refactors with no design content. The plan-stage step is explicitly skipped when "the diff describes itself in one sentence." Don't ceremoniously critique the trivial.
+
+### 3. Blinding Has to Match the Stage
+
+The most subtle lesson in this workflow is that "fresh context" isn't a single rule. The plan-stage critic _needs_ intent to do its job; the code-review critic needs to be _denied_ intent to do its job. Same word ("fresh context"), opposite rules. The reason is that the two stages are reasoning about different artifacts — a plan, which is partly intent by construction, vs. code, which is supposed to stand on its own.
+
+**When to apply:** Any review process where you have multiple stages of criticism. The blinding rules for each stage should match what that stage is trying to evaluate. A design review of a mockup probably _wants_ to see the brief; a usability test of the resulting UI probably does _not_.
+
+**When to question:** When a process treats all reviews symmetrically. "Always blind the reviewer" and "always give the reviewer full context" are both wrong in the wrong place.
+
+### 4. Cap the Number of Critic Passes — Conditionally
+
+Adding critique passes feels productive. It usually isn't, past one. The diminishing-returns finding shows up across the reflection-loop literature with enough consistency that defaulting to one pass and conditionally allowing a second is the right starting position. If the first pass produced structural objections that reshaped the plan, a second pass might surface knock-on effects worth catching. If the first pass produced no material issues, a second pass mostly produces invented ones.
+
+**When to apply:** Any agentic-critique loop. LLM reflection loops. Human code review with a "let me take one more look" reflex. Workshop-style group critique.
+
+**When to lean the other way:** High-stakes or irreversible changes. A surgical procedure deserves more than one pre-incision checklist pass. A database migration that drops tables deserves more than one review. Cap your defaults; raise the cap for the cases where the asymmetry of consequences justifies it.
+
+### 5. Document the Requirements; Link Out for Mechanics
+
+The cleanest separation between `CLAUDE.md` and the `git-github-workflow` skill is the requirements/mechanics split. `CLAUDE.md` says _what every change must do_. The skill says _how to do it_. When the requirements change, you edit `CLAUDE.md`. When the mechanics change (a new flag in `setup-worktree.py`, a new branch-naming convention), you edit the skill. Both documents stay short, both stay opinionated, and they never drift out of sync because they cover non-overlapping ground.
+
+**When to apply:** Any time you have two related documents and you're choosing how to split the content. Ask "which is canonical for which audience?" and put a clear one-direction reference between them.
+
+**When to question:** When one of the two documents starts repeating chunks of the other. That's the drift starting. Re-establish the split, or merge the two.
+
+## Going Deeper
+
+### Related Concepts
+
+**Plan-mode workflows in agentic coding.** The plan-stage critique step assumes a `Plan`-mode flow where the agent drafts an approach before writing code. This isn't universal in agentic systems — many "just go" — but it's increasingly the recommended pattern for non-trivial changes because it makes intent legible at exactly the moment when intent is cheapest to revise.
+
+**Double-blind review in academia.** The code-review-stage blinding rule is the same intuition that double-blind peer review is built on. The author's framing of what the work is _about_ biases what reviewers attend to. Removing the framing redirects reviewer attention back to the artifact itself.
+
+**Reflection loops in LLM reasoning.** The "default cap of one pass" decision draws on findings from the reflection-and-revise literature (Reflexion and follow-ups) showing that the marginal value of additional critique passes drops quickly. The specific cap is a project choice; the underlying finding is robust across replications.
+
+**The Checklist Manifesto.** The seven-step process is, structurally, a checklist. Checklists work because they remove decisions about _what to do next_ at moments when those decisions are easy to skip ("we don't need that step _this time_"). The reason the workflow is codified at all is that "what's the next step?" should never depend on the author's energy on a given day.
+
+### Other Teaching Docs in This Repo
+
+- [`0.1-git-worktrees-parallel-development.md`](./0.1-git-worktrees-parallel-development.md) — Where the worktree-based development model originated. The seven-step process builds on the assumption that every change happens in a short-lived worktree.
+- [`0.3-code-quality-automation.md`](./0.3-code-quality-automation.md) — How the automated checks in step 3 are set up (ESLint, Prettier, Husky pre-commit hooks). The fresh-context code review in step 4 picks up where the automation leaves off.
+- [`0.6-code-review-documentation.md`](./0.6-code-review-documentation.md) — The structured format the code-reviewer subagent uses to deliver its findings. This document is the "why" of the review step; that document is the "how" of the review output.
+- [`0.7-architecture-decision-records.md`](./0.7-architecture-decision-records.md) — How larger architectural decisions get captured. ADRs and teaching docs are complementary: ADRs are the decision; teaching docs are the elaboration.
+
+## Questions to Think About
+
+1. **The asymmetry.** Why is it that intent helps a plan-stage critic but hurts a code-stage critic? Can you think of a third stage of review where the blinding rule would be different still?
+
+2. **The one-pass cap.** When is a second pre-implementation critique pass _worth_ the cost? What's the signal you'd look for in the first pass that would justify spawning a second?
+
+3. **The dual source of truth.** If `CLAUDE.md` and the `git-github-workflow` skill both ended up describing "how to create a worktree," which one would you edit first to fix the drift? Why?
+
+4. **The dead-letter window.** The migration leaves `.shared/CLAUDE.md` orphaned for the period between PR merge and post-merge cleanup. Is there a sequencing that would close that window entirely, and what would it cost?
+
+5. **The exit signal.** The workflow requires a critic to explicitly say "no material issues" when there are none, and explicitly says "do not reward critics that invent issues to justify their turn." How would you actually detect, in practice, that a critic _is_ inventing issues? What would the warning sign look like?
+
+---
+
+**Key takeaway:** The thing that makes this workflow worth codifying isn't any individual step. It's the combination of (a) doing critique twice, at two different stages, (b) blinding the two critique stages differently because they're evaluating different artifacts, (c) capping the critique passes so the workflow doesn't reward invented issues, and (d) putting the rules in a tracked file so future readers can see them, change them, review the changes, and watch the workflow evolve under its own scrutiny. The seven steps are the surface. The reasons behind each step — and the deliberate non-symmetry between the two critic stages — are the substance.

--- a/init-shared.sh
+++ b/init-shared.sh
@@ -12,55 +12,9 @@ mkdir -p "$SHARED_DIR/.planning"
 mkdir -p "$SHARED_DIR/.scratch"
 mkdir -p "$SHARED_DIR/.claude"
 
-# Create CLAUDE.md with project context
-cat > "$SHARED_DIR/CLAUDE.md" << 'EOF'
-# BroteinBuddy
-
-A Progressive Web App for tracking protein shake inventory by flavor and location.
-
-## Tech Stack
-- Svelte + TypeScript
-- Vite
-- Vitest (unit/integration), Playwright (E2E), @testing-library/svelte
-- LocalStorage for persistence
-- PWA (installable on iOS)
-- Deployed on Vercel
-
-## Key Features
-- Weighted random flavor selection
-- Visual inventory management with drag-and-drop rearrange
-- Box location tracking with conflict resolution
-- Configurable favorite flavor quick-pick
-- Smart box selection (open before unopened, lower qty first)
-
-## Development Standards
-See the `brotein-buddy-standards` skill for:
-- Git workflow: feature/* branches, squash merge to main
-- Many small commits, not big commits after-the-fact
-- Testing requirements: 90% coverage overall, 100% for critical paths
-- All tests must pass before merge
-- Code quality: ESLint + Prettier + Husky pre-commit hooks
-- Documentation: README (user-facing), DEVELOPING (dev-facing), ADRs for decisions
-
-## Project Structure
-```
-BroteinBuddy/
-├── wt/                       # All worktrees
-│   ├── main/                # Main branch
-│   └── feature-*/           # Feature branches
-├── .shared/                  # Shared files (symlinked to worktrees)
-│   ├── CLAUDE.md            # This file
-│   ├── CLAUDE_CONTEXT.md    # Confidential context
-│   ├── .planning/           # Planning documents
-│   ├── .scratch/            # Throwaway files
-│   └── .claude/             # Claude Code settings
-├── src/                     # Source code
-├── tests/                   # Tests
-└── docs/                    # Documentation (ADRs, etc.)
-```
-
-See DEVELOPING.md for detailed setup and architecture information.
-EOF
+# CLAUDE.md is no longer created here. It is now a tracked file in the
+# repo and is populated into every worktree by `git checkout` automatically.
+# This script only seeds the files that remain personal / shared-local.
 
 # Create CLAUDE_CONTEXT.md with confidential information
 cat > "$SHARED_DIR/CLAUDE_CONTEXT.md" << 'EOF'
@@ -133,14 +87,11 @@ echo ""
 echo "✅ .shared directory initialized at: $SHARED_DIR"
 echo ""
 echo "Files created:"
-echo "  - CLAUDE.md (project context)"
 echo "  - CLAUDE_CONTEXT.md (confidential - job application info)"
 echo "  - .planning/ (for implementation plan and planning docs)"
 echo "  - .scratch/ (for throwaway files)"
 echo "  - .claude/settings.local.json (Claude Code settings)"
-echo "  - .claude/skills/ → $CENTRAL_SKILLS"
+echo "  - .claude/skills/ -> $CENTRAL_SKILLS"
 echo ""
-echo "Next steps:"
-echo "  1. Review and customize .shared/CLAUDE.md if needed"
-echo "  2. Run ./setup-worktree.sh main to create main worktree"
-echo "  3. Move this implementation plan to .shared/.planning/PLAN.md"
+echo "Note: CLAUDE.md is tracked in git and populated by 'git checkout'"
+echo "      into every worktree - no need to seed it here."


### PR DESCRIPTION
## Summary

- Move `CLAUDE.md` from a personal symlinked file in `.shared/` into the git tree as a tracked file.
- Drop the `CLAUDE.md` entry from `.gitignore` (`CLAUDE_CONTEXT.md` stays, it's confidential).
- Rewrite the content to reflect the 2026 codebase: Supabase sync, offline event timeline, Backup & Restore, drop the obsolete `/agents` known-issue block, and codify the workflow standards (short-lived worktrees, plan-stage critique, fresh-context code review, teaching-mentor docs).

## Why

Symlinking `CLAUDE.md` from `.shared/` made it invisible to git and required every worktree to symlink it via `setup-worktree.py`. Tracking it directly:

- Lets `git checkout` populate every worktree automatically.
- Gives the content a real edit/review history.
- Removes the dual-source-of-truth risk where someone edits `.shared/CLAUDE.md` expecting it to propagate.

The companion `custom-claude-skills` PR ([#32](https://github.com/nikblanchet/claude-skills/pull/32), merged) already removed the `CLAUDE.md` symlink step from `setup-worktree.py`, so new worktrees won't collide with the tracked file.

## Workflow standards in the refreshed content

> [!NOTE]
> The skill (`git-github-workflow`) remains canonical for the **mechanics** (worktree setup, branch naming, post-merge cleanup). The new `CLAUDE.md` states the **requirements** and links out, to avoid duplicated-source-of-truth drift.

The new `CLAUDE.md` codifies, with reasoning:

- Every change happens in a short-lived worktree, squash-merged, then deleted.
- **Plan-stage critique** by a fresh-context structured devil's advocate before any code is written. Default 1 pass; conditional 2nd only if pass 1 surfaced structural reshape. Skip for one-sentence changes.
- **Fresh-context code review** on the diff only. The reviewer does NOT see the PR description, commit messages, or planning docs — research shows authorial intent measurably biases the review (Wang et al. 2025).
- **Teaching-mentor write-up** in `docs/teaching/` as the final step before squash-merge.
- Asymmetry between the two critique stages: the plan-stage critic SHOULD see the goal (plan IS intent); the code-review critic should NOT see authorial intent.

## What's NOT in this PR

- `.shared/CLAUDE.md` deletion. Doing it pre-merge would break `main/`'s symlink while this PR is in review. Post-merge follow-up.
- `.bare/info/exclude` already had its `CLAUDE.md` line removed in the local clone during this work (it's not git-tracked).
- Three pre-existing modifications on tracked `.claude/` symlinks (path correction from `../../../` to `../../`) noticed during this work but reset — unrelated to CLAUDE.md tracking; deserves its own focused PR if anyone wants to clean those up.

## Migration steps after merge

Strict order, otherwise `main/`'s `CLAUDE.md` symlink shadows the tracked file:

1. **In `main/`:** `rm CLAUDE.md` (delete the symlink), then `git pull` (gets the tracked file).
2. Repeat the same in any other active worktree.
3. **Once all worktrees have the tracked file:** `rm /Users/nik/Documents/Code/repos/BroteinBuddy/.shared/CLAUDE.md` to retire the old source of truth.

## Test Plan

- [x] `npm test` — 604 tests pass, 17 skipped (unchanged from main).
- [x] `npm run lint` — no errors.
- [x] `npm run build` — built successfully.
- [x] `git check-ignore CLAUDE.md` returns nothing (the new file is no longer excluded).
- [ ] After merge: `git ls-files CLAUDE.md` lists it as tracked.
- [ ] After merge: new worktrees created via the updated `setup-worktree.py` contain `CLAUDE.md` via checkout, not via symlink.

> [!IMPORTANT]
> This PR exercises Step 4 of its own newly-codified workflow: when you are ready, point a fresh-context code-reviewer subagent at the diff. The reviewer should not be told this PR description or the planning context. The bugfix PR (rearrange-scroll) will follow this one and be the first end-to-end exercise of the new process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)