### PR TITLE
Fix rearrange screen scrolling so off-screen stacks are reachable

### DIFF
--- a/docs/teaching/2.9-scrollport-pattern-and-touch-drag-tradeoffs.md
+++ b/docs/teaching/2.9-scrollport-pattern-and-touch-drag-tradeoffs.md
@@ -1,0 +1,382 @@
+# The Scrollport Pattern, Touch-Drag Trade-offs, and Honest Testing of a DnD Library
+
+**Deliverable:** 2.9 — Fix Rearrange screen scrolling so off-screen stacks are reachable (PR #99, branch `bug/rearrange-scroll`)
+**Author:** Claude Code (Teaching Mentor Subagent)
+**Date:** 2026-05-21
+**Skill Level:** Intermediate / CSS layout + library interaction
+
+---
+
+## Table of Contents
+
+1. [What We Built](#what-we-built)
+2. [Why This Approach](#why-this-approach)
+   - [The Problem We Solved](#the-problem-we-solved)
+   - [Why It Wasn't Obvious](#why-it-wasnt-obvious)
+3. [How It Works](#how-it-works)
+   - [Part 1 — The Scrollport Pattern](#part-1--the-scrollport-pattern)
+   - [Part 2 — The Touch-Hold Delay](#part-2--the-touch-hold-delay)
+   - [Part 3 — Keyboard-Driven End-to-End Coverage](#part-3--keyboard-driven-end-to-end-coverage)
+4. [Design Trade-offs](#design-trade-offs)
+5. [Real-World Compromises](#real-world-compromises)
+6. [What You Should Learn From This](#what-you-should-learn-from-this)
+7. [Going Deeper](#going-deeper)
+8. [Questions to Think About](#questions-to-think-about)
+
+---
+
+## What We Built
+
+A bug report: "When I try to rearrange boxes, the screen is not scrollable. I can rearrange boxes on the stacks that are visible, but I cannot move boxes from, into, or between stacks I would have to scroll down to see."
+
+Three small changes, each independently revertable:
+
+1. **A CSS scrollport fix on `.rearrange-container`.** Five property declarations, the heart of the bug.
+2. **A `delayTouchStart: 150` on the `dndzone` config.** A one-line touch-UX adjustment to keep the now-scrollable screen actually scrollable with a finger.
+3. **An E2E regression test suite.** Three new tests that prove the scrollport works, that off-screen content becomes reachable after scrolling, and — most interestingly — that a full cross-stack drag completes via the library's keyboard API.
+
+The diff is small. The reasons each piece exists are not, and that's what this document is about. The CSS fix touches a layout pattern (the "scrollport") that's worth knowing in any framework. The touch-delay involves a perceptual UX trade-off where iOS conventions, library defaults, and gesture semantics all interact. And the testing pivot — from pointer-based drag to keyboard-based drag — is a worked example of choosing a test mechanism that matches what the library was designed for, rather than fighting the library's runtime behavior with brittle mouse interpolation.
+
+This PR was also the first to walk end-to-end through the workflow codified in [`0.5-workflow-as-codified-process.md`](./0.5-workflow-as-codified-process.md). It went through plan-stage critique, two fresh-context code review passes, a teaching write-up (this document), and gated hardware verification on iOS PWA. The second code review pass surfaced a subtle bug in a test comment that the author had rationalized away on the first read — we'll come back to that, because it's a small but pure illustration of what blind review catches.
+
+## Why This Approach
+
+### The Problem We Solved
+
+If you grow the inventory past the point where all stacks fit on a phone screen, the rearrange screen reports them all in a grid — but the grid extends below the viewport, and nothing scrolls. You can see, in the inspector, that the page knows about stacks 7 and 8. You just can't reach them. Long-pressing a box near the bottom edge and dragging downward does nothing; the box drags into the visible region and stops; the off-screen stacks remain off-screen.
+
+The root cause was a four-line CSS mistake compounded by an app-shell design that's correct in isolation. The Rearrange route declared:
+
+```css
+.rearrange-container {
+  padding: var(--space-4);
+  max-width: 1200px;
+  margin: 0 auto;
+  min-height: 100vh;
+}
+```
+
+That `min-height: 100vh` is the smoking gun. It says: "this element must be at least one full viewport tall." Combined with the absence of any `overflow-y` declaration, this means: when the content exceeds 100vh, the element grows past the viewport, and there is no scrollport — no element on the ancestor chain that says "I am the scroll context; scroll me." So the user can't scroll, and neither can `svelte-dnd-action`'s edge auto-scroll, which walks up the parent chain looking for a scrollable ancestor and falls back to nothing.
+
+The app-shell side of this is a deliberate design decision worth pausing on. `App.svelte`'s `.main` grid cell looks like this:
+
+```css
+.main {
+  grid-area: main;
+  min-height: 0;
+  overflow: hidden;
+}
+```
+
+That `overflow: hidden` is not a bug. It's the chosen convention for this app: **the app shell does not own scroll; each route owns its own scroll context.** Why? Because routes have radically different scroll needs — `Inventory.svelte` has a floating action button that should stay clear of bottom safe-area, `Home.svelte` has a centered card layout that doesn't scroll at all, and `Rearrange` needs a scrollport that the dnd library can latch onto. Putting `overflow-y: auto` on `.main` would centralize scroll in a way that's wrong for at least two of those three routes, and it would also break the FAB-clear bottom padding pattern that `Inventory.svelte` relies on.
+
+So `.main` is deliberately a non-scroller. The contract is: every route mounted into `.main` must establish its own scroll context if it has scrolling content. `Inventory.svelte` does this correctly — it has `overflow-y: auto`, `height: 100%`, and `box-sizing: border-box`. `Rearrange` didn't. That's the bug.
+
+### Why It Wasn't Obvious
+
+The bug is the kind that sits in a blind spot for a while because the page _looks_ correct at desk-screen widths. On a 1440px-wide monitor with the inventory at small-to-medium size, every stack fits without overflow. Nothing demands a scrollport, because there's no content past the fold. The bug is invisible until either (a) the viewport gets small (phone), or (b) the inventory gets large (eight stacks). The intersection of those two conditions is exactly the iOS PWA use case — and exactly when a real user, on their phone, would hit it.
+
+This is one of those bugs that's easier to find by reading the layout intent than by browsing the screen. The phrase "min-height: 100vh, no overflow-y, child of overflow: hidden" is enough, by itself, to predict the symptom. But it doesn't show up in tests that don't seed enough stacks to overflow on the smallest viewport. Worth keeping in mind: the absence of overflow is testable, but only if your test seeds something that should overflow.
+
+## How It Works
+
+### Part 1 — The Scrollport Pattern
+
+The fix turns `.rearrange-container` into a scrollport. Here's the before-and-after:
+
+```css
+/* Before */
+.rearrange-container {
+  padding: var(--space-4);
+  max-width: 1200px;
+  margin: 0 auto;
+  min-height: 100vh; /* overshoots, doesn't scroll */
+}
+
+/* After */
+.rearrange-container {
+  height: 100%; /* fills the 1fr .main grid row */
+  overflow-y: auto; /* this element is now the scroll context */
+  box-sizing: border-box; /* padding counts toward the 100% height */
+  padding: var(--space-4) var(--space-4) var(--space-8);
+  max-width: 1200px;
+  margin: 0 auto;
+}
+```
+
+Each property is pulling its weight. Let's walk through them.
+
+**`height: 100%`** replaces `min-height: 100vh`. The difference matters. `min-height: 100vh` says "be at least one viewport tall," which on a phone with the URL bar and AppNav visible is taller than the available `.main` grid cell — the route would overshoot its parent. `height: 100%` says "fill exactly the height your grid-cell parent offers you," which is the right size, no more, no less. The `.main` cell is the `1fr` row in `App.svelte`'s `auto 1fr auto` grid, so its height is "whatever's left after the topbar and nav," which is exactly the height the route should fill.
+
+**`overflow-y: auto`** is the actual scrollport declaration. With this property, the browser knows: if the children of this element exceed its height, render a vertical scrollbar (or, on touch, allow inertial scroll) and clip what doesn't fit. Without this property, the children overflow visibly and there's no scroll affordance. This is also the property that `svelte-dnd-action` looks for when it walks up the DOM searching for a scrollable ancestor.
+
+**`box-sizing: border-box`** makes the `height: 100%` include the padding rather than add the padding on top. Without `border-box`, `100% + var(--space-4) + var(--space-8)` would be _taller_ than the grid cell, and we'd be right back in the overshoot situation. The app sets `box-sizing: border-box` globally via `:global(*)` in `App.svelte`, so this declaration is technically redundant — but it's an explicit reminder of what the math is doing, which matters when a future reader is trying to understand why `height: 100%` doesn't blow out the parent. (`Inventory.svelte` does the same thing for the same reason.)
+
+**The padding asymmetry** — `var(--space-4) var(--space-4) var(--space-8)` instead of the original even `var(--space-4)` — adds extra breathing room at the bottom so the Confirm/Cancel actions don't sit flush against the scrollport's bottom edge. There's no FAB on this screen so we don't need the `96px` FAB-clearance that `Inventory.svelte` uses, but a touch of extra bottom padding makes the layout feel finished.
+
+Now, here's the part that connects the CSS to the dnd library. `svelte-dnd-action`'s auto-scroll-during-drag works by walking up the DOM from each registered dropzone and asking each ancestor: "is your computed `overflow` value `auto` or `scroll`?" If yes, that ancestor goes into a set of scrollable containers. During drag, when the pointer is near a containing rectangle's edge, the library scrolls the deepest containing scroller in that direction. The exact code in the library lives in `helpers/multiScroller.js`:
+
+```js
+function findScrollableParents(element) {
+  if (!element) return [];
+  const scrollableContainers = [];
+  let parent = element;
+  while (parent) {
+    const { overflow } = window.getComputedStyle(parent);
+    if (overflow.split(' ').some((o) => o.includes('auto') || o.includes('scroll'))) {
+      scrollableContainers.push(parent);
+    }
+    parent = parent.parentElement;
+  }
+  return scrollableContainers;
+}
+```
+
+Read that loop carefully. It checks `overflow`, not `overflow-y`. It does include shorthand expansions in modern browsers, but the point is: this is a textual property check, not a semantic check. If your scrollport is established via `overflow-y` alone, the library still finds it because `getComputedStyle(parent).overflow` returns a combined value that includes both axes. The fix works because once `.rearrange-container` has `overflow-y: auto`, the library's walk finds it. Before the fix, the walk reached `.main` (which is `overflow: hidden` — not auto, not scroll, doesn't qualify), then the body element (no overflow set), then bottomed out at the document scrolling element (which is also clipped at viewport height by the app shell's `height: 100%`). Nothing in the chain qualified. With the fix, the very first parent qualifies. Edge auto-scroll has something to grab.
+
+This is the takeaway worth bottling: **the scrollport pattern is two-handed.** One hand says "I am the scroll context." The other hand requires that no ancestor is _also_ a scroll context that swallows the gesture first. Both have to be true for an external library that walks the parent chain to behave correctly. `Inventory.svelte` got this right by accident, because it follows the same convention; `Rearrange` got it wrong; the fix restores the contract.
+
+### Part 2 — The Touch-Hold Delay
+
+Once `.rearrange-container` is scrollable on a phone, a new problem appears that didn't exist before: the user's finger has to disambiguate between "I'm flicking the page to scroll" and "I'm picking up a box to drag." Before the fix, this wasn't an issue because there was no scroll to compete with; every touch on a box was unambiguously a drag attempt.
+
+`svelte-dnd-action` has a configuration knob for this, `delayTouchStart`. The library's default is `false` (no delay) or, if you set it to literal `true`, an 80ms delay. From `pointerAction.js`:
+
+```js
+const DEFAULT_TOUCH_DELAY_MS = 80;
+```
+
+We set it to a specific number instead:
+
+```svelte
+use:dndzone={{
+  items: boxes.map((b) => b.box),
+  flipDurationMs: 200,
+  dropTargetStyle: {},
+  // 150ms touch hold (not the library default of 80ms when
+  // set to `true`) so iOS PWA touch-scroll inside the new
+  // scrollport is not hijacked as a drag on quick flicks.
+  // 150ms matches iOS's typical long-press convention; 80ms
+  // leaves a perceptual dead-zone where a short tap is
+  // neither a complete flick nor a held-drag.
+  delayTouchStart: 150,
+}}
+```
+
+Why 150ms and not 80ms? Three reasons, layered.
+
+**First, iOS's long-press convention.** Native iOS long-press menus and context actions kick in at around 150ms of held contact (it's been tuned in the system across versions, but ~150ms is the conventional perceptual threshold users have internalized). Setting the dnd delay to 150ms means a press long enough to feel like "I'm holding something" engages the drag, and a press shorter than that feels like a tap or a flick and lets the scrollport handle it.
+
+**Second, the dead-zone at 80ms.** A delay short enough that a user can't reliably _not_ hit it — 80ms — creates a perceptual dead zone. Quick flicks-to-scroll will sometimes engage the drag (the finger paused for 90ms while traveling), and intentional drags will sometimes feel sluggish (the user expects an instant response, gets a sub-frame delay they can't perceive as intentional). The middle is worse than either pole. Either commit to "no delay, drags are instant" (which we can't — that breaks scrolling) or commit to "drags require a clear hold" (150ms, which we can).
+
+**Third, the asymmetry.** The delay only affects `touchstart`. Mouse users — desk-screen, laptop trackpad — don't pay the cost. The library wires the delay to the touch path specifically, gated on `isTouch && config.delayTouchStartMs > 0` in `pointerAction.js`. So the trade-off is: touch users pay a 150ms latency on drag initiation, and in exchange, scrolling works. Mouse users get no latency, because they didn't have a competing gesture to disambiguate. This is the right shape of trade-off — pay the cost on the user class that benefits from the disambiguation, not on the class that doesn't need it.
+
+It's worth saying explicitly: the touch-delay tweak is _only_ a problem because the scrollport fix exists. Before the scrollport, there was no scroll-vs-drag ambiguity, because scroll wasn't possible. Solving the first problem created the second; the 150ms is the answer to the second. This kind of cascading fix is common in CSS work — adding scroll affordances tends to expose latent gesture conflicts — and the right move is to ship the cascade as a single PR (or as carefully sequenced commits within one PR) so the regression-set covers both.
+
+### Part 3 — Keyboard-Driven End-to-End Coverage
+
+The PR includes three new E2E tests, seeded with eight stacks at iPhone-SE viewport so vertical overflow is forced. The first two are straightforward:
+
+```ts
+test('should be scrollable when stacks overflow the viewport', async ({ page }) => {
+  // ...seed...
+  const container = page.locator('.rearrange-container');
+  const { scrollH, clientH } = await container.evaluate((el) => ({
+    scrollH: el.scrollHeight,
+    clientH: el.clientHeight,
+  }));
+  expect(scrollH).toBeGreaterThan(clientH);
+  // ...
+});
+```
+
+That's the scrollport invariant — content exceeds container — and a verification that a stack starting off-screen scrolls into view. The second test confirms an off-screen box stays interactable after scrolling. These two are deterministic and engine-agnostic.
+
+The third test is the interesting one, and it's the one that took an honest pivot to land. The plain-English thing the bug reporter wanted to confirm was: "I can drag a box into an off-screen stack." Translating that directly into Playwright meant simulating a pointer-based drag: `await box.hover()`, `page.mouse.down()`, `page.mouse.move()` along a path, `page.mouse.up()` at the target. That's the obvious test. It does not work reliably.
+
+The reason it doesn't work is a subtle interaction with how `svelte-dnd-action` updates its UI mid-drag. The library fires `consider` events continuously while the user is dragging, and `consider` updates the local `boxes` array in the Svelte component — which causes Svelte to re-render the grid. The grid uses `grid-template-columns: repeat(auto-fit, minmax(180px, 1fr))`, so adding or removing items from a stack triggers a column re-flow. The target stack you were aiming at can move under the cursor mid-drag, sometimes by tens of pixels. Playwright's mouse interpolation doesn't recompute the target's screen coordinates mid-path; it computes the path once at hover-time and walks it. The cursor arrives at where the target _used to be_, the drop fires on whatever happens to be under it now, and the test ends up either landing on the wrong stack or, worse, succeeding on one engine and failing on another.
+
+We tried the pointer-based approach and it was brittle. The honest thing to do at this point is not to add `waitForTimeout` calls and hope, but to ask: **is there a test mechanism that the library was actually designed for?**
+
+There is. `svelte-dnd-action` ships keyboard support specifically for accessibility:
+
+- Focused item, press `Space` (or `Enter`): start a drag. `handleDragStart` fires, `isDragging` becomes true.
+- Tab to a different `dndzone`: the library's `handleZoneFocus` (in `keyboardAction.js` lines 88–118) synchronously removes the item from the source zone, inserts it into the target zone, and dispatches `finalize` on both.
+
+That second bullet is worth re-reading. The cross-zone move happens **on the target-zone focus event**, not on a subsequent keypress. There is no "Space to drop" step after focusing the target. The library's keydown listener is attached only to draggable children, not to zones (see `keyboardAction.js` line 324), so a second `Space` after `targetZone.focus()` is a no-op — at best harmless, at worst misleading.
+
+The keyboard path doesn't depend on pointer interpolation through a reflowing grid. Focus is set programmatically; the library's listeners do the rest synchronously. The result is engine-agnostic and reproducible. The new test uses exactly this path:
+
+```ts
+const sourceBox = page.locator('[data-box-id="box-7a"]');
+const targetZone = page.locator('[data-stack="8"] .stack-boxes');
+await expect(sourceBox).toBeInViewport();
+await expect(targetZone).toBeInViewport();
+
+await sourceBox.focus();
+await page.keyboard.press('Space'); // lifts box-7a (handleDragStart)
+await targetZone.focus(); // triggers handleZoneFocus -> the move
+
+// Wait past flipDurationMs so finalize handlers have settled.
+await page.waitForTimeout(300);
+
+// Click Confirm and verify the location update was persisted.
+const confirmButton = page.getByRole('button', { name: /confirm/i });
+await confirmButton.scrollIntoViewIfNeeded();
+await confirmButton.click();
+```
+
+That `await expect(sourceBox).toBeInViewport()` and the matching one on `targetZone` are not decorative. They are the assertions that couple this test to the scrollport fix. Without the CSS change, `.main { overflow: hidden }` clips stacks 7 and 8 below the fold, the preceding `container.scrollTop = container.scrollHeight` is a no-op (nothing to scroll), and both `toBeInViewport` assertions fail. The test is designed so the regression — losing the scrollport — flips it to red.
+
+Here's the part that's most worth lingering on, because it's the workflow story landing on this exact test. The first version of this test had a trailing `await page.keyboard.press('Space')` after `targetZone.focus()`, with a comment explaining that this was "the drop." The second fresh-context code reviewer flagged it. Going back to `node_modules/svelte-dnd-action/src/keyboardAction.js`, the library doesn't fire on a `Space` after zone focus — the move is on the focus event itself. The author had described the test in terms of intuitive expectations ("focus the zone, then press a key to commit") rather than what the library actually does. A reviewer who hadn't read the library's source rationalized the comment as plausible. A reviewer who had no prior intent visible and was forced to verify against the source flagged the contradiction. The fix is commit `0eb0ab0`: remove the trailing `Space`, rewrite the comment to cite the library's line numbers, explicitly note that the keydown listener is wired to children (not zones).
+
+This is a small bug in a comment in a test file. It would not have shipped a regression to users. But it would have shipped _wrong knowledge_ about how the library works — knowledge that a future developer reading this test for an unrelated reason might have absorbed as truth. The fresh-context review found it on a second pass because the second reviewer wasn't reading my reasoning; they were reading the code, and the code said something the comment didn't.
+
+## Design Trade-offs
+
+### What We Optimized For
+
+**A scrollport pattern that an external library can detect without configuration.** We could have used `overflow: scroll` (forces a scrollbar even when not needed), `overflow: hidden` plus a custom JS scroll handler (decouples from the library and breaks edge auto-scroll), or `overflow: clip` (a newer property that doesn't establish a scroll context at all). `overflow-y: auto` is the right answer because (a) it scrolls only when needed, (b) `svelte-dnd-action`'s text-match on the computed `overflow` value picks it up, and (c) it matches what `Inventory.svelte` already does — consistency across routes makes the contract legible.
+
+**A touch-delay that aligns with iOS conventions, not with framework defaults.** The library's `delayTouchStart: true` ergonomic shorthand is 80ms — a number that's a reasonable default for desktop touch but is in the perceptual dead-zone for phone users. Picking 150ms explicitly trades 70ms of drag-initiation latency for fewer accidental drag triggers on flick gestures, with the latency justified by matching the user's existing mental model of "hold to interact."
+
+**Test deterministic to the library's design intent.** The keyboard-drag E2E exercises the same `handleDndConsider`/`handleDndFinalize` pipeline as a pointer drag would, gets the same `localBoxes` mutation, and persists to LocalStorage the same way — but it does so via a code path the library was explicitly designed to support, and that doesn't depend on pointer interpolation through a reflowing grid.
+
+### What We Sacrificed
+
+**Pointer-event coverage in automated tests.** There is no automated test in this PR that simulates a real touch drag with auto-scroll. That coverage moved to the manual hardware verification checklist (see the PR body), because we found we couldn't write a reliable pointer-based version. The trade-off: the keyboard test exercises the validation logic deterministically; the hardware checklist proves the touch path works on real iOS Safari. Neither alone is sufficient; together they cover what we need.
+
+**Touch-drag latency for all touch users, even those not on the scrollable route.** The 150ms `delayTouchStart` applies on every Rearrange dropzone, including on desk-screen laptops with touchscreens where scrolling isn't competing. We considered gating the delay at runtime with `matchMedia('(pointer: coarse)').matches` to apply it only on phone-class inputs, and decided against the added complexity. The cost is small (a 150ms first-touch delay that a touchscreen-laptop user might briefly notice), and the gate would be one more thing to maintain. If a touchscreen-laptop user ever complains, the gate is the fallback.
+
+**An immediate "drop the box" affordance on touch.** With the 150ms delay, a user who wants to drag a box has to commit to holding for that long. A user who taps quickly and expects an instant response gets nothing. This is the same trade-off that native iOS makes for long-press menus, so users are likely to absorb it, but it's worth naming: every touch UX choice that disambiguates two gestures by time imposes a wait on at least one of them.
+
+## Real-World Compromises
+
+### The Pointer-Drag Pivot
+
+The original plan included a pointer-based E2E test that would drag a box into an off-screen stack with `page.mouse.down`, a path of `page.mouse.move` calls, and `page.mouse.up`. The plan-stage critic had flagged that the existing "scrollHeight > clientHeight" check was a tautology — it tests that `overflow-y: auto` overflows, which is what the CSS just declared — and asked for a test that exercised the actual user complaint: dragging into an off-screen stack.
+
+We wrote the pointer-based version. It was brittle. It passed on Desktop Chrome and failed on Mobile Safari with `Expected to be in viewport, received not in viewport` on the wrong stack. The root cause turned out to be the mid-drag grid reflow described earlier — Playwright's mouse interpolation doesn't track moving targets.
+
+The pivot to keyboard-drag was made over a couple of code-review cycles. The first review's concern #1 said: "E2E coverage stops one step short of the actual user complaint — no test exercises a real drag into an off-screen stack." The response wasn't "add `waitForTimeout` calls"; it was to ask whether the library exposes a different mechanism that would test the same pipeline more reliably. It does. The keyboard test was added, the pointer test was abandoned. The remaining pointer-drag coverage is on the manual hardware checklist, where it belongs — real touch hardware exercises the path that pointer-event simulation cannot reliably exercise.
+
+The general lesson: when a test feels like it's fighting a runtime, the test mechanism is probably wrong. Try a mechanism the runtime was designed for. If there isn't one, the test belongs on a manual checklist, not in CI.
+
+### The `box-error` Tooltip Position
+
+`.box-error` is `position: absolute; bottom: -24px;` on each box visual. Before the scrollport fix, this absolute positioning produced no observable problem — the parent didn't clip, so the error text could overflow visually outside the box and still be readable. After the scrollport fix, the parent _does_ clip on its boundary, and an error-text element with a `bottom: -24px` offset on a box at the scrollport's lower edge could theoretically be cut off.
+
+This was flagged in both code reviews. Neither flagged it as a blocker; both flagged it as something to verify on hardware. The PR's manual checklist includes "Validation error case — error text below the box is not clipped by scrollport." If the visual confirms a clip, the follow-up is to convert the absolute positioning to flow layout. We chose not to do that preemptively because (a) the absolute positioning predates this PR, (b) it's only theoretically affected by the change, and (c) the manual check is cheap. This is the right shape of compromise: surface the risk explicitly, gate it on the verification step, defer the speculative fix.
+
+### The Existing-Test Hardening
+
+The existing `should show confirm and cancel buttons` test originally just asserted visibility. The PR's diff adds `await confirm.scrollIntoViewIfNeeded()` before the assertion. As of this seed, that scroll is a no-op — the confirm button is visible in the default viewport. So why add it?
+
+Defensive forward-compatibility. The new tests prove the scrollport works at iPhone-SE with eight stacks. If seed data grows in some future PR — say, to twelve stacks — the existing visibility test could silently start failing on Mobile Safari with the button below the fold. Adding the `scrollIntoViewIfNeeded` is cheap insurance that the existing assertion remains meaningful regardless of seed size. The second code review flagged this as a no-op today; the response is recorded in the review-response table: "Defensive forward-compatibility for seed growth. Costs nothing."
+
+This is a small thing, but it's one of those judgment calls that matters in long-lived test suites. A test that becomes meaningless under a future seed change is worse than a test that's a no-op today. The forward-compatibility cost is one line of test code; the alternative cost is a future bisect to figure out why the visibility test started failing after a seed PR that "couldn't possibly have caused it."
+
+### The Code-Review Pass That Found the Comment Bug
+
+This deserves its own note because it's the most pure example of why blind code review catches what the author misses.
+
+After the first fresh-context review, the author had added the keyboard-drag E2E test with a `Space` press after `targetZone.focus()` and a comment explaining that the `Space` was the drop. The first reviewer didn't flag it — the keyboard test was new, and they evaluated whether it covered the regression (yes) and whether its mechanism was sound (mostly yes). The trailing `Space` looked plausible.
+
+The second fresh-context review, on the updated diff, flagged it. The reviewer's concern #1 was: "The keyboard test's `Space` after `targetZone.focus()` is dead code. The actual cross-stack move happens on zone focus via `handleZoneFocus` (keyboardAction.js lines 88–118)." That's the kind of finding that requires opening the library's source and reading it carefully. The reviewer had no access to the author's chat-time reasoning, the planning doc, or the PR description. They were forced to verify the comment against the code.
+
+The author had absorbed the intuition "you focus the target and then commit with a keypress" from how pointer-based drags work — focus then click. Once it was in the comment, the author rationalized it. The library doesn't actually work that way; the synchronous move on focus is documented in the library's source but easy to miss because it's not the cross-cutting metaphor a developer brings with them. The blind reviewer didn't have that metaphor pre-installed; they verified instead.
+
+Commit `0eb0ab0` removed the trailing `Space` and rewrote the comment to cite the library's exact behavior. The test still passes — and now its comment matches what's actually happening. Future readers of the test won't absorb the wrong mental model about how `svelte-dnd-action` keyboard drag works.
+
+## What You Should Learn From This
+
+### 1. The Scrollport Pattern: One Element Owns Scroll, Ancestors Stay Out of the Way
+
+When you build a multi-route app with a shell that has overflow rules, decide explicitly which layer owns scroll. The most flexible answer is usually: **the route owns scroll**, the shell is `overflow: hidden`, and each route declares its own scrollport with `height: 100%; overflow-y: auto; box-sizing: border-box`. This pattern lets each route choose its own scroll behavior (none, vertical, internal-only) without coordinating with the shell.
+
+If you're integrating an external library that walks the DOM looking for a scrollable ancestor (`svelte-dnd-action` does this, `react-window` does this, most virtualization libraries do this), the route-owns-scroll pattern is also the pattern those libraries assume. Putting scroll on the shell would force you to either configure the library to skip the shell or to introduce a confusing intermediate scroller.
+
+**When to apply:** Multi-route apps with distinct per-route scroll needs. Apps using a library that detects scrollable ancestors. Apps where different routes have different bottom-content (FABs, action bars, no extra UI).
+
+**When to question:** Single-purpose apps where the shell scroll is the only scroll. Apps where scroll position should persist across routes (one big scroll context might be simpler).
+
+### 2. Touch-Drag Disambiguation Is a Time Trade-off
+
+When a touch surface has to disambiguate two gestures — scroll vs. drag, tap vs. long-press, swipe vs. flick — you pay for the disambiguation in time. Either you pick a delay (drag requires a hold), a movement threshold (drag requires a minimum pixel travel before commitment), or a region (drag handle on the corner of the item). All three are valid; all three have UX consequences.
+
+The time-based approach is the simplest and is what most touch libraries expose. The cost is asymmetric latency: the long-tail gesture (drag) pays the delay; the common gesture (scroll) doesn't, because if the user lifts before the delay elapses, no drag fires and the scroll continues uninterrupted. Match the delay to an existing user mental model — iOS's ~150ms long-press is one — so the cost feels like the platform, not like an unfamiliar quirk of your app.
+
+**When to apply:** Any touch UI with overlapping gestures on the same target. Long-press menus. Drag-and-drop. Pull-to-refresh.
+
+**When to question:** Touch UIs where the gestures are spatially separable (drag handles, dedicated regions) — a region-based disambiguation gives you no-delay drags and no-delay scrolls, at the cost of an extra UI affordance.
+
+### 3. Choose Test Mechanisms That Match the Library's Design Intent
+
+When you're testing a library's behavior end-to-end, the cleanest tests use the API the library was designed for. Pointer-event simulation _looks_ universal because every interactive library accepts pointer events at the bottom of its stack, but the library's higher-level abstractions are often easier to drive directly. If a library supports keyboard interactions for accessibility — which most well-designed UI libraries do — keyboard tests are usually deterministic, fast, and engine-agnostic in ways pointer tests can't match.
+
+The pivot isn't "give up on pointer testing." It's "if pointer testing fights the runtime, ask whether the library has a different driver." Often the answer is yes, and the keyboard or programmatic API gives you the same coverage with none of the flakiness.
+
+**When to apply:** Testing libraries that have explicit accessibility support (keyboard navigation, ARIA roles), or libraries with programmatic APIs that mirror their interaction APIs. Testing libraries whose UI reflows during interaction.
+
+**When to question:** Testing UIs where pointer precision is itself what you're validating (drawing tools, fine-grained gesture recognizers). Testing pure mouse-only UIs.
+
+### 4. The Scrollport Walk Is Two-Handed
+
+When you make an element a scrollport, you're committing to two things at once: declaring that this element is a scroll context, and verifying that no ancestor pre-empts the scroll. Forgetting either half produces silent breakage. An element with `overflow-y: auto` whose parent is _also_ scrollable will lose the gesture to the parent. An element with `overflow-y: auto` whose parent is `overflow: hidden` and has no scroll behavior is fine — but if you mistakenly put `overflow: hidden` on the supposed scrollport itself, you've made everything below it inaccessible.
+
+This is the kind of pattern that's easier to verify by inspecting the DOM than by reading any single CSS file. When debugging a "page won't scroll" bug, walk up the DOM, log `getComputedStyle(el).overflow` for each ancestor, and the broken contract becomes visible immediately.
+
+**When to apply:** Debugging scroll bugs. Integrating libraries that walk the parent chain.
+
+**When to question:** Single-element pages. iframe-bound content where the iframe owns the scroll context.
+
+### 5. Blind Review Catches What Sighted Review Rationalizes
+
+This is the third teaching doc in a row to note this and it keeps being worth saying. The second code review pass on this PR caught a small but real bug in a test comment that the author had rationalized into existence and the first reviewer hadn't flagged. The reason it got caught the second time wasn't that the reviewer was smarter; it was that the reviewer had no access to the author's mental model. Without the "Space focuses then commits" metaphor pre-installed in their head, they had to verify what the comment claimed by reading the library's source. The library's source disagreed. The fix shipped before merge.
+
+If you only take one practice from this PR, take this one: **review the code, not the description**. Even on your own work. The description tells you what the author thought they were doing. The code tells you what the program does. Those two are not always the same, and the gap is where the bugs live.
+
+**When to apply:** Always, on code review of non-trivial diffs.
+
+**When to question:** Single-line fixes where the description is the same as the diff. Don't fetishize blinding when the diff is one-glance comprehensible.
+
+## Going Deeper
+
+### Related Concepts
+
+**Computed `overflow` vs. declared `overflow-y`.** Most browsers return a combined `overflow` value from `getComputedStyle` that reflects both axes' settings. Libraries that string-match the computed `overflow` (like `svelte-dnd-action`) pick up `overflow-y: auto` correctly. But the corollary is: if you ever switch to `overflow: clip` on either axis, libraries may stop detecting the element as scrollable. The `clip` value doesn't establish a scroll context the way `auto`/`scroll` do.
+
+**Box-sizing and grid-row sizing.** `box-sizing: border-box` is critical when you combine `height: 100%` with internal padding inside a grid row. Without `border-box`, the height computation excludes padding and the element overshoots its grid cell. The app's `:global(*) { box-sizing: border-box }` rule makes this implicit globally; declaring it explicitly in the scrollport's CSS is a documentation choice — it makes the math legible to a future reader who doesn't know about the global rule.
+
+**Touch-delay vs. movement-threshold.** Libraries that disambiguate scroll-vs-drag with a time-based delay (svelte-dnd-action's `delayTouchStart`) are easier to configure than libraries that use a movement-threshold (e.g., react-dnd's `delay` or `touchStartThreshold`). The trade-off is that delay-based disambiguation introduces latency on the drag path; threshold-based disambiguation introduces uncertainty (a user trying to drag a tiny amount may not cross the threshold). Pick the one that matches your interaction pattern; protein-shake-box-sized targets work fine with delay-based.
+
+**The `svelte-dnd-action` keyboard contract.** Read `node_modules/svelte-dnd-action/src/keyboardAction.js` if you ever need to write a keyboard-driven test against this library. The key lines are:
+
+- 88–118: `handleZoneFocus` — the cross-zone move synchronously happens here.
+- 230–254: `handleDragStart` — Space or Enter on a focused item commits the lift.
+- 324: the keydown listener is wired only to draggable children.
+
+The contract is: Space lifts, Tab navigates between zones (focusing a zone fires the move), Space on the source ends the drag, Escape cancels. If you write a test that uses keyboard interaction with this library and it doesn't behave as you expect, start by reading these line numbers.
+
+### Other Teaching Docs in This Repo
+
+- [`2.5-inventory-management-screen.md`](./2.5-inventory-management-screen.md) — Where the `Inventory.svelte` scrollport pattern was first established. The fix in this PR brings `Rearrange` into alignment with that pattern.
+- [`2.7-drag-drop-interfaces.md`](./2.7-drag-drop-interfaces.md) — The original write-up of the rearrange screen and `svelte-dnd-action` usage. This document is its sequel; if `2.7` is the "how the drag-and-drop works" story, this is the "how the drag-and-drop interacts with the scrollport (and what happens when that interaction is wrong)" story.
+- [`2.6-e2e-debugging-methodology.md`](./2.6-e2e-debugging-methodology.md) — The methodology for debugging flaky E2E tests. The pointer-drag pivot in this PR is an applied case study of that methodology: when a test fights the runtime, change the test mechanism.
+- [`0.5-workflow-as-codified-process.md`](./0.5-workflow-as-codified-process.md) — The seven-step process this PR is the first to walk through end-to-end. The "second code review caught a comment bug" story belongs to that codified workflow.
+
+## Questions to Think About
+
+1. **The two-handed scrollport.** What if you needed a route that had _two_ independent scroll regions side by side — a list on the left and a detail view on the right, both scrolling independently? How would the scrollport pattern need to change, and what would `svelte-dnd-action` see when it walks up the parent chain from a draggable inside one of them?
+
+2. **The 150ms cost.** Suppose a usability test reveals that touchscreen-laptop users (Surface, iPad with Magic Keyboard) find the 150ms drag delay sluggish. What changes? Do you introduce a `pointer: coarse` media query gate, do you switch to a movement-threshold disambiguation, or do you keep the delay and live with the friction? What signal in the usability data would distinguish those options?
+
+3. **The pointer-test gap.** The PR ships with a keyboard-driven E2E test and a manual hardware checklist. What's the cost-benefit of writing a flaky-but-real pointer-drag test gated behind a `test.skip()` so it can be unmuted for one-off verification, vs. relying entirely on the manual checklist? When would the cost of maintaining the flaky test exceed the cost of the hardware check?
+
+4. **The comment-bug case.** The trailing-`Space` comment described behavior the library doesn't have. A future developer reading that test might absorb the wrong mental model. What kind of automated check (lint rule, doc test, schema validation) could catch the mismatch between a test's narrative and the library's actual behavior? Or is that the kind of thing that's irreducibly a human-review job?
+
+5. **The scrollport invariant test.** The first new test asserts `scrollHeight > clientHeight` after seeding eight stacks at iPhone-SE viewport. A plan-stage critic flagged that this is partly tautological — `overflow-y: auto` overflows when content exceeds container, that's its definition. What's the value of the test anyway, and what would it catch that a unit test of the CSS rule couldn't?
+
+---
+
+**Key takeaway:** A small bugfix can be a teaching opportunity if you treat the surrounding decisions seriously. The scrollport pattern is a CSS technique with a real interaction-design contract — one element owns scroll, no ancestor pre-empts it — and it's the same contract that external libraries assume when they walk the parent chain. The touch-delay is a time-trade-off that turns a scroll-vs-drag ambiguity into a scroll-by-default-with-drag-on-hold gesture model, and the right number for the delay is the one that matches the user's existing mental model of the platform. The testing pivot is a case study in matching the test mechanism to the library's design intent rather than fighting the library's runtime with brittle pointer simulation. None of these lessons is exotic, but each is the kind of detail that's easy to gloss past in a small-diff PR — and easy to remember once you've worked through them with a real bug as the anchor.

--- a/src/routes/InventoryRearrange.svelte
+++ b/src/routes/InventoryRearrange.svelte
@@ -181,6 +181,7 @@
             items: boxes.map((b) => b.box),
             flipDurationMs: 200,
             dropTargetStyle: {},
+            delayTouchStart: 150,
           }}
           onconsider={(e) => handleDndConsider(e, Number(stackNum))}
           onfinalize={(e) => handleDndFinalize(e, Number(stackNum))}

--- a/src/routes/InventoryRearrange.svelte
+++ b/src/routes/InventoryRearrange.svelte
@@ -181,6 +181,12 @@
             items: boxes.map((b) => b.box),
             flipDurationMs: 200,
             dropTargetStyle: {},
+            // 150ms touch hold (not the library default of 80ms when
+            // set to `true`) so iOS PWA touch-scroll inside the new
+            // scrollport is not hijacked as a drag on quick flicks.
+            // 150ms matches iOS's typical long-press convention; 80ms
+            // leaves a perceptual dead-zone where a short tap is
+            // neither a complete flick nor a held-drag.
             delayTouchStart: 150,
           }}
           onconsider={(e) => handleDndConsider(e, Number(stackNum))}

--- a/src/routes/InventoryRearrange.svelte
+++ b/src/routes/InventoryRearrange.svelte
@@ -218,10 +218,12 @@
 
 <style>
   .rearrange-container {
-    padding: var(--space-4);
+    height: 100%;
+    overflow-y: auto;
+    box-sizing: border-box;
+    padding: var(--space-4) var(--space-4) var(--space-8);
     max-width: 1200px;
     margin: 0 auto;
-    min-height: 100vh;
   }
 
   header {

--- a/tests/e2e/rearrange.spec.ts
+++ b/tests/e2e/rearrange.spec.ts
@@ -82,8 +82,14 @@ test.describe('Inventory Rearrange', () => {
   test('should show confirm and cancel buttons', async ({ page }) => {
     await page.goto('/#/inventory/rearrange');
 
-    await expect(page.getByRole('button', { name: /confirm/i })).toBeVisible();
-    await expect(page.getByRole('button', { name: /cancel/i })).toBeVisible();
+    // Now that .rearrange-container is a scrollport, future seed growth
+    // could push the buttons below the fold. scrollIntoViewIfNeeded keeps
+    // the existing visibility assertion meaningful regardless of seed size.
+    const confirm = page.getByRole('button', { name: /confirm/i });
+    const cancel = page.getByRole('button', { name: /cancel/i });
+    await confirm.scrollIntoViewIfNeeded();
+    await expect(confirm).toBeVisible();
+    await expect(cancel).toBeVisible();
   });
 
   test('should navigate back on cancel', async ({ page }) => {
@@ -138,5 +144,128 @@ test.describe('Inventory Rearrange', () => {
 
     await expect(page.locator('h1')).toHaveText('Rearrange Boxes');
     await expect(page.locator('text=Drag boxes to reorder')).toBeVisible();
+  });
+});
+
+/**
+ * Regression coverage for the "screen is not scrollable" bug: with enough
+ * stacks to overflow the viewport, the user could not reach stacks below
+ * the fold to drag boxes from / into / between them. Root cause was the
+ * .rearrange-container lacking overflow-y while .main is overflow: hidden,
+ * so no ancestor was a scrollport. These tests seed eight stacks at
+ * iPhone-SE viewport so overflow is forced, then prove both that the
+ * container scrolls and that a box can land in a stack that started off
+ * the visible area.
+ */
+test.describe('Inventory Rearrange - scrolling with many stacks', () => {
+  test.beforeEach(async ({ page, context }) => {
+    // Seed 8 stacks with 2 boxes each (16 boxes total). Two reasons for
+    // the 2-per-stack shape: (a) 8 stacks at iPhone-SE width is 4 rows
+    // tall, which forces vertical overflow regardless of small engine
+    // differences; (b) when we drag a box out of its source stack later,
+    // the source stack keeps its remaining box - so it does not vanish
+    // from the grid mid-drag and reflow the target's screen coordinates.
+    await context.addInitScript((key) => {
+      const flavors = Array.from({ length: 8 }, (_, i) => ({
+        id: `f${i + 1}`,
+        name: `Flavor ${i + 1}`,
+        randomPool: 'caffeine-free' as const,
+      }));
+      const boxes = Array.from({ length: 8 }, (_, stackIdx) => [
+        {
+          id: `box-${stackIdx + 1}a`,
+          flavorId: `f${stackIdx + 1}`,
+          quantity: 12,
+          location: { stack: stackIdx + 1, height: 1 },
+          isOpen: false,
+        },
+        {
+          id: `box-${stackIdx + 1}b`,
+          flavorId: `f${stackIdx + 1}`,
+          quantity: 12,
+          location: { stack: stackIdx + 1, height: 2 },
+          isOpen: false,
+        },
+      ]).flat();
+      localStorage.setItem(
+        key,
+        JSON.stringify({
+          version: 2,
+          boxes,
+          flavors,
+          favoriteFlavorId: null,
+          settings: {},
+        })
+      );
+    }, STORAGE_KEY);
+
+    await page.setViewportSize({ width: 375, height: 667 });
+    await page.goto('/#/');
+
+    try {
+      const startFreshButton = page.getByRole('button', { name: /start fresh/i });
+      await startFreshButton.waitFor({ state: 'visible', timeout: 2000 });
+      await startFreshButton.click();
+      await page.waitForTimeout(500);
+    } catch {
+      // Modal didn't appear, continue
+    }
+  });
+
+  test('should be scrollable when stacks overflow the viewport', async ({ page }) => {
+    await page.goto('/#/inventory/rearrange');
+
+    const container = page.locator('.rearrange-container');
+    await expect(container).toBeVisible();
+
+    // Scrollport invariant: the container has more content than fits.
+    // This is the cheap deterministic guard - if it ever regresses, the
+    // CSS scrollport change was lost.
+    const { scrollH, clientH } = await container.evaluate((el) => ({
+      scrollH: el.scrollHeight,
+      clientH: el.clientHeight,
+    }));
+    expect(scrollH).toBeGreaterThan(clientH);
+
+    // A stack that started off-screen becomes reachable via scroll.
+    const lastStack = page.locator('[data-stack="8"]');
+    await expect(lastStack).toBeAttached();
+    await lastStack.scrollIntoViewIfNeeded();
+    await expect(lastStack).toBeInViewport();
+  });
+
+  test('off-screen stacks become interactable after scrolling', async ({ page }) => {
+    // After the scrollport fix, the user can scroll a stack that started
+    // below the fold into view. This test proves that once scrolled in,
+    // the stack's box is actually reachable - that is, its center is in
+    // the visible portion of the viewport, hovering it does not throw,
+    // and the page does not auto-scroll it back out from under us.
+    //
+    // We deliberately do NOT exercise the full drag-and-drop pipeline
+    // here. svelte-dnd-action 0.9.69 listens to pointer events and
+    // reorders the grid mid-drag (the consider event updates localBoxes
+    // before drop, which reflows the column-fit grid). Playwright's
+    // mouse interpolation through a reflowing layout is brittle: the
+    // target's screen position shifts under the cursor mid-path, and
+    // the final dropzone is non-deterministic across engines. The
+    // rearrange logic itself is covered by unit tests in
+    // tests/unit/rearrange-utils.test.ts (simulateMove,
+    // reorderBoxesAfterMove, validateRearrangementState), and the
+    // end-to-end drag-into-off-screen-stack behavior is on the manual
+    // hardware verification checklist in the PR description.
+    await page.goto('/#/inventory/rearrange');
+
+    const container = page.locator('.rearrange-container');
+    await container.evaluate((el) => {
+      el.scrollTop = el.scrollHeight;
+    });
+
+    const lastStackBox = page.locator('[data-box-id="box-8a"]');
+    await expect(lastStackBox).toBeInViewport();
+
+    // Hovering must not throw and the element must remain interactable
+    // after the hover settles - this is the precondition for any drag.
+    await lastStackBox.hover();
+    await expect(lastStackBox).toBeInViewport();
   });
 });

--- a/tests/e2e/rearrange.spec.ts
+++ b/tests/e2e/rearrange.spec.ts
@@ -159,12 +159,12 @@ test.describe('Inventory Rearrange', () => {
  */
 test.describe('Inventory Rearrange - scrolling with many stacks', () => {
   test.beforeEach(async ({ page, context }) => {
-    // Seed 8 stacks with 2 boxes each (16 boxes total). Two reasons for
-    // the 2-per-stack shape: (a) 8 stacks at iPhone-SE width is 4 rows
-    // tall, which forces vertical overflow regardless of small engine
-    // differences; (b) when we drag a box out of its source stack later,
-    // the source stack keeps its remaining box - so it does not vanish
-    // from the grid mid-drag and reflow the target's screen coordinates.
+    // Seed 8 stacks with 2 boxes each (16 boxes total). 8 stacks at
+    // iPhone-SE width is 4 rows in a 2-column auto-fit grid, which
+    // forces vertical overflow regardless of small engine differences.
+    // 2 boxes per stack keeps every source stack populated after a
+    // keyboard cross-stack drag, so groupBoxesByStack does not drop
+    // the stack from the rendered grid and shift other stacks around.
     await context.addInitScript((key) => {
       const flavors = Array.from({ length: 8 }, (_, i) => ({
         id: `f${i + 1}`,
@@ -236,24 +236,16 @@ test.describe('Inventory Rearrange - scrolling with many stacks', () => {
 
   test('off-screen stacks become interactable after scrolling', async ({ page }) => {
     // After the scrollport fix, the user can scroll a stack that started
-    // below the fold into view. This test proves that once scrolled in,
-    // the stack's box is actually reachable - that is, its center is in
-    // the visible portion of the viewport, hovering it does not throw,
-    // and the page does not auto-scroll it back out from under us.
-    //
-    // We deliberately do NOT exercise the full drag-and-drop pipeline
-    // here. svelte-dnd-action 0.9.69 listens to pointer events and
-    // reorders the grid mid-drag (the consider event updates localBoxes
-    // before drop, which reflows the column-fit grid). Playwright's
-    // mouse interpolation through a reflowing layout is brittle: the
-    // target's screen position shifts under the cursor mid-path, and
-    // the final dropzone is non-deterministic across engines. The
-    // rearrange logic itself is covered by unit tests in
-    // tests/unit/rearrange-utils.test.ts (simulateMove,
-    // reorderBoxesAfterMove, validateRearrangementState), and the
-    // end-to-end drag-into-off-screen-stack behavior is on the manual
-    // hardware verification checklist in the PR description.
+    // below the fold into view. This test proves the stack started off
+    // screen, that scrolling brings it in, and that its box remains
+    // interactable after scrolling settles.
     await page.goto('/#/inventory/rearrange');
+
+    const lastStack = page.locator('[data-stack="8"]');
+    // Pre-condition: stack 8 is NOT in the viewport before scrolling.
+    // Without this, the test could silently pass on a future viewport
+    // widening or seed shrink that brings stack 8 into the initial view.
+    await expect(lastStack).not.toBeInViewport();
 
     const container = page.locator('.rearrange-container');
     await container.evaluate((el) => {
@@ -262,10 +254,61 @@ test.describe('Inventory Rearrange - scrolling with many stacks', () => {
 
     const lastStackBox = page.locator('[data-box-id="box-8a"]');
     await expect(lastStackBox).toBeInViewport();
-
-    // Hovering must not throw and the element must remain interactable
-    // after the hover settles - this is the precondition for any drag.
     await lastStackBox.hover();
     await expect(lastStackBox).toBeInViewport();
+  });
+
+  test('keyboard-driven cross-stack rearrange works after scrolling', async ({ page }) => {
+    // Closes the regression-coverage gap left by the lack of a pointer-
+    // drag test: this exercises the full dnd pipeline (focus -> lift ->
+    // tab into another zone -> drop) through to a localBoxes update via
+    // svelte-dnd-action's keyboard support. Deterministic across engines
+    // because it doesn't depend on pointer interpolation through a
+    // mid-drag-reflowing grid.
+    //
+    // Keyboard contract (svelte-dnd-action 0.9.69, src/keyboardAction.js):
+    //   - Items receive focus via Tab when not dragging.
+    //   - Space or Enter on a focused item lifts it (isDragging=true).
+    //   - During drag, items get tabIndex=-1 and valid drop zones get
+    //     tabIndex=0, so Tab moves focus between zones.
+    //   - Space or Enter on a focused zone (or its child) drops there.
+    await page.goto('/#/inventory/rearrange');
+
+    const container = page.locator('.rearrange-container');
+    await container.evaluate((el) => {
+      el.scrollTop = el.scrollHeight;
+    });
+
+    const sourceBox = page.locator('[data-box-id="box-7a"]');
+    const targetZone = page.locator('[data-stack="8"] .stack-boxes');
+    await expect(sourceBox).toBeInViewport();
+    await expect(targetZone).toBeInViewport();
+
+    // Focus the source box. The library wires keydown to each dndzone
+    // child, so the keydown fires on the dragged item.
+    await sourceBox.focus();
+    await page.keyboard.press('Space'); // lift
+
+    // Tab to the adjacent zone (stack 8). Items inside stack 7 have
+    // tabIndex=-1 during drag, so Tab skips them and lands on the
+    // next focusable zone or item in document order.
+    await targetZone.focus();
+    await page.keyboard.press('Space'); // drop
+
+    // Wait past flipDurationMs so finalize handlers have settled.
+    await page.waitForTimeout(300);
+
+    // Click Confirm and verify the location update was persisted.
+    const confirmButton = page.getByRole('button', { name: /confirm/i });
+    await confirmButton.scrollIntoViewIfNeeded();
+    await confirmButton.click();
+
+    await expect(page).toHaveURL('/#/inventory');
+    const state = await page.evaluate(
+      (key) => JSON.parse(localStorage.getItem(key) ?? '{}'),
+      STORAGE_KEY
+    );
+    const movedBox = state.boxes.find((b: { id: string }) => b.id === 'box-7a');
+    expect(movedBox?.location?.stack).toBe(8);
   });
 });

--- a/tests/e2e/rearrange.spec.ts
+++ b/tests/e2e/rearrange.spec.ts
@@ -260,18 +260,34 @@ test.describe('Inventory Rearrange - scrolling with many stacks', () => {
 
   test('keyboard-driven cross-stack rearrange works after scrolling', async ({ page }) => {
     // Closes the regression-coverage gap left by the lack of a pointer-
-    // drag test: this exercises the full dnd pipeline (focus -> lift ->
-    // tab into another zone -> drop) through to a localBoxes update via
-    // svelte-dnd-action's keyboard support. Deterministic across engines
-    // because it doesn't depend on pointer interpolation through a
-    // mid-drag-reflowing grid.
+    // drag test: this exercises the full dnd pipeline through to a
+    // localBoxes update via svelte-dnd-action's keyboard support.
+    // Deterministic across engines because it doesn't depend on pointer
+    // interpolation through a mid-drag-reflowing grid.
+    //
+    // The two assertions that the scrollport fix is required:
+    //   - expect(sourceBox).toBeInViewport()
+    //   - expect(targetZone).toBeInViewport()
+    // both placed AFTER the scrollTop assignment. Without the CSS fix
+    // (which adds `overflow-y: auto` and `height: 100%` so the container
+    // becomes a real scrollport), .main's `overflow: hidden` clips
+    // stacks 7 and 8 below the fold and `scrollTop = scrollHeight` is a
+    // no-op - so both assertions fail and the test rightly flags the
+    // regression.
     //
     // Keyboard contract (svelte-dnd-action 0.9.69, src/keyboardAction.js):
     //   - Items receive focus via Tab when not dragging.
-    //   - Space or Enter on a focused item lifts it (isDragging=true).
-    //   - During drag, items get tabIndex=-1 and valid drop zones get
-    //     tabIndex=0, so Tab moves focus between zones.
-    //   - Space or Enter on a focused zone (or its child) drops there.
+    //   - Space or Enter on a focused item calls handleDragStart -
+    //     isDragging becomes true.
+    //   - Focusing a *different* dndzone while isDragging fires
+    //     handleZoneFocus (lines 88-118), which SYNCHRONOUSLY removes
+    //     the item from the source zone's items, inserts it into the
+    //     target zone's items, and dispatches finalize on both zones.
+    //   - That is: the move happens on the target-zone focus event,
+    //     not on a subsequent Space press. The library's keydown
+    //     listener is wired to draggable children only, not zones
+    //     (keyboardAction.js line 324), so a Space after zone focus
+    //     would be a no-op.
     await page.goto('/#/inventory/rearrange');
 
     const container = page.locator('.rearrange-container');
@@ -284,16 +300,9 @@ test.describe('Inventory Rearrange - scrolling with many stacks', () => {
     await expect(sourceBox).toBeInViewport();
     await expect(targetZone).toBeInViewport();
 
-    // Focus the source box. The library wires keydown to each dndzone
-    // child, so the keydown fires on the dragged item.
     await sourceBox.focus();
-    await page.keyboard.press('Space'); // lift
-
-    // Tab to the adjacent zone (stack 8). Items inside stack 7 have
-    // tabIndex=-1 during drag, so Tab skips them and lands on the
-    // next focusable zone or item in document order.
-    await targetZone.focus();
-    await page.keyboard.press('Space'); // drop
+    await page.keyboard.press('Space'); // lifts box-7a (handleDragStart)
+    await targetZone.focus(); // triggers handleZoneFocus -> the move
 
     // Wait past flipDurationMs so finalize handlers have settled.
     await page.waitForTimeout(300);


### PR DESCRIPTION
## Summary

`.rearrange-container` is now a scrollport (`height: 100%; overflow-y: auto; box-sizing: border-box`), so the user can scroll to stacks below the fold and `svelte-dnd-action`'s edge auto-scroll has a scrollable ancestor to operate on during drag. `delayTouchStart: 150` is added to the dnd config so quick flicks-to-scroll on iOS PWA are not hijacked as drags.

Three commits, each independently revertable:
1. **`aaf425c`** — CSS scrollport change on `.rearrange-container`.
2. **`d7dc1c8`** — `delayTouchStart: 150` on the `dndzone` config.
3. **`5db2e85`** — E2E coverage and an existing-test hardening.

## Why

> When I try to rearrange boxes, the screen is not scrollable. I am able to rearrange boxes on the stacks that are visible, but I cannot move boxes from, into, or between stacks that I would have to scroll down to see.

Root cause: `.rearrange-container` had `min-height: 100vh` and no `overflow-y`, while its grid-cell parent `.main` is `overflow: hidden`. No ancestor on the chain was a scrollport — so the user could not manually scroll, and `svelte-dnd-action`'s edge auto-scroll had nothing to grab.

## Workflow exercised

This PR is the first to run through the workflow codified in PR #98:

- **Plan-stage critique:** ran a fresh-context structured devil's advocate on the draft plan; surfaced ~18 issues, addressed materially before any code was written. See `/Users/nik/.claude/plans/we-ve-got-a-bugfix-unified-rivest.md`.
- **Fresh-context code review:** _to run on the diff for this PR (no PR description / planning / commits visible to the reviewer)._
- **Teaching-mentor write-up:** _to run after code review blockers are resolved and user confirms ready to merge._

## Test plan

> [!IMPORTANT]
> Manual hardware verification on iOS PWA is mandatory before merge. The unit tests cover the validation logic; the E2E tests cover the scrollport invariant; only hardware can prove the dnd library's edge auto-scroll engages on real iOS Safari.

### Automated

- [x] `npm test` — 604 unit tests pass, 17 skipped (unchanged).
- [x] `npm run lint` — clean.
- [x] `npm run build` — succeeded.
- [x] `npx playwright test rearrange.spec.ts` — 10 passed on Desktop Chrome.
- [x] `npx playwright test rearrange.spec.ts --project='Mobile Safari'` — 10 passed.

### Manual hardware (gating)

- [ ] Install PWA on iOS device. Open Rearrange with 8+ stacks.
- [ ] Container scrolls when content overflows.
- [ ] Long-press a box, slowly drag toward the top/bottom edge — edge auto-scroll engages.
- [ ] Drop a box into a previously-off-screen stack — location updates after Confirm.
- [ ] Quick flick gestures meant as scroll do not trigger drag (`delayTouchStart` working).
- [ ] Validation error case — error text below the box is not clipped by scrollport.
- [ ] Keyboard drag (Space+Arrow) — focused element scrolls into view automatically off-screen.

## Why no E2E test for drag-into-off-screen-stack

`svelte-dnd-action` 0.9.69 listens to pointer events and reorders the grid mid-drag (the `consider` event updates `localBoxes` before drop, which reflows the column-fit grid). Playwright's mouse interpolation through a reflowing layout is non-deterministic: the target's screen coordinates shift under the cursor mid-path, and the final dropzone varies across engines. The underlying rearrange logic is covered by unit tests in `tests/unit/rearrange-utils.test.ts`; the end-to-end drag is on the manual hardware checklist above.

## Follow-up work noted (out of scope)

- **Phone rearrange UX.** Even with edge auto-scroll, edge-scroll-while-dragging on a 4-finger-tall touchscreen is awkward. The CSS fix is a minimum unblocker; a phone-friendly affordance (tap-source -> tap-destination, list view, or stack picker) deserves an ADR.
- **Accessibility deepening.** aria-label audit on draggables, VoiceOver behavior with `delayTouchStart`, broader keyboard-drag coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)