### PR TITLE
Drop "follow-up PR" parenthetical from CLAUDE.md step 4

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ All work happens in a short-lived worktree branched from `main`, squash-merged, 
 
 3. **Local checks pass.** `npm test`, `npm run lint`, `npm run build`.
 
-4. **Fresh-context code review.** Spawn a new `code-reviewer` subagent in a clean session. The reviewer reads only the diff and the existing codebase. **It does NOT read the PR description, planning docs, or commit messages** — those leak authorial intent and bias the review. (This supersedes earlier guidance in `git-github-workflow/references/code-reviewer-guide.md`, which is being updated in a follow-up PR to match.)
+4. **Fresh-context code review.** Spawn a new `code-reviewer` subagent in a clean session. The reviewer reads only the diff and the existing codebase. **It does NOT read the PR description, planning docs, or commit messages** — those leak authorial intent and bias the review. See `git-github-workflow/references/code-reviewer-guide.md` for the full invocation prompt and blinding contract.
 
 5. **Address blockers.** Small commits per fix. Re-run the fresh-context review if post-review changes are non-trivial.
 


### PR DESCRIPTION
## Summary

- One-sentence cleanup: the parenthetical in `CLAUDE.md` "Process before every merge" step 4 noted that `code-reviewer-guide.md` "is being updated in a follow-up PR to match." That follow-up shipped as [`custom-claude-skills` PR #33](https://github.com/nikblanchet/claude-skills/pull/33) (squash commit `0a1ddcf`, merged 2026-05-21), so the parenthetical is outdated.
- Replaced with a plain pointer: "See `git-github-workflow/references/code-reviewer-guide.md` for the full invocation prompt and blinding contract."

Trivial enough to skip plan-stage critique and fresh-context code review per the workflow's "skip when the diff fits in one sentence" rule.

## Test plan

- [ ] No code paths touched; no test or build runs needed beyond husky's pre-commit hooks (passed locally on commit).
- [ ] After merge, the link from `CLAUDE.md` step 4 to `code-reviewer-guide.md` lands on the rewritten file with no contradictory framing.

Generated with [Claude Code](https://claude.com/claude-code)