### PR TITLE
Document the missing bare-repo fetch refspec in bootstrap

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -15,6 +15,13 @@ a child of `BroteinBuddy/`. To set this up from scratch:
 mkdir BroteinBuddy && cd BroteinBuddy
 git clone --bare git@github.com:nikblanchet/brotein-buddy.git .bare
 
+# 1b. Replace the --bare default fetch refspec (which maps heads/heads and
+#     collides with worktree branches) with the normal-clone refspec, then
+#     populate refs/remotes/origin/*. Without this, `git log origin/main`
+#     silently lies — origin/main never advances even though fetches succeed.
+git --git-dir=.bare config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
+git --git-dir=.bare fetch origin
+
 # 2. Tell git this directory is backed by .bare.
 echo "gitdir: ./.bare" > .git
 
@@ -72,6 +79,18 @@ ln -sfn ../../.shared/.claude/settings.local.json .claude/settings.local.json
 New worktrees created via `setup-worktree.py` already produce these symlinks
 with the correct two-level (`../../`) target paths, so this manual step is
 only needed for worktrees that pre-date the cleanup.
+
+If your clone was created before step 1b above was documented, `.bare/config`
+likely has no fetch refspec under `[remote "origin"]` (or has the `--bare`
+default `+refs/heads/*:refs/heads/*`), so `git fetch` populates objects but
+never advances `refs/remotes/origin/*`. `git log origin/main` will silently
+show stale commits even after a successful fetch. Patch the refspec once:
+
+```bash
+git --git-dir=<repo-root>/.bare config remote.origin.fetch \
+    '+refs/heads/*:refs/remotes/origin/*'
+git --git-dir=<repo-root>/.bare fetch origin
+```
 
 ### Creating New Worktrees
 


### PR DESCRIPTION
## Summary

- New step 1b in the new-machine bootstrap: after `git clone --bare`, replace the default `+refs/heads/*:refs/heads/*` refspec with the normal-clone refspec (`+refs/heads/*:refs/remotes/origin/*`) and prime `refs/remotes/origin/*` with an initial fetch.
- A short paragraph in **Migrating an existing clone** that patches older clones (with either no refspec or the `--bare` default) with the same one-line config command.

## Why

`git clone --bare` defaults to mirror-mode refs that collide with worktree branches, so PR #100 dropped the refspec from `.bare/config` entirely. That fix landed us in the worst-of-both: `git fetch origin` happily downloads objects but never advances `refs/remotes/origin/*`, so `git log origin/main` silently returns stale commits no matter how many fetches you run. The local fix is one `git config` line; this PR puts it in the documented bootstrap so future clones don't repeat the issue.

Diff is two small text blocks in DEVELOPING.md — fits the "describes itself in one sentence" criteria for skipping plan-stage critique and fresh-context code review.

## Test plan

- [x] Applied the same `git config remote.origin.fetch ...` on this clone; `git fetch origin` now advances `refs/remotes/origin/main` to match GitHub (`d56ff95` after PR #102 merged), and previously-invisible feature branches show up under `refs/remotes/origin/*`.
- [ ] Verify on next new-machine bootstrap (or by following the migration paragraph on another existing clone): `git log origin/main` should show the actual GitHub HEAD after fetch.

Generated with [Claude Code](https://claude.com/claude-code)